### PR TITLE
Preserve Brave Paws camera pairing metadata

### DIFF
--- a/apps/brave-paws-app/src/components/SessionConfig.tsx
+++ b/apps/brave-paws-app/src/components/SessionConfig.tsx
@@ -132,7 +132,7 @@ export function SessionConfig({ initialSession, cameraUrl = '', onCameraUrlChang
           <h2 className="text-lg font-bold text-slate-800">Remote Stream Link (Optional)</h2>
         </div>
         <p className="text-sm text-slate-500 mb-4">
-          Scan the QR code from Brave Paws Streamer, or paste the simplified camera URL manually if needed.
+          Scan the QR code from Brave Paws Streamer, or paste the full pairing link manually if needed.
         </p>
         <CameraLinkInput
           cameraUrl={cameraUrl}

--- a/apps/brave-paws-app/src/utils/cameraUrl.ts
+++ b/apps/brave-paws-app/src/utils/cameraUrl.ts
@@ -87,13 +87,43 @@ function extractCameraLaunchConfig(value: string): CameraLaunchConfig {
   };
 }
 
-export function normalizeCameraUrlValue(value: string): string {
-  const config = extractCameraLaunchConfig(value);
+function serializeCameraLaunchConfig(config: CameraLaunchConfig, options: { preservePairingLink?: boolean } = {}): string {
   if (!config.cameraUrl) {
     return '';
   }
 
-  return config.cameraUrl;
+  const sanitizedCameraUrl = sanitizeCameraUrl(config.cameraUrl);
+  if (!sanitizedCameraUrl) {
+    return '';
+  }
+
+  const profile = sanitizeCameraProfile(config.profile);
+  const mode = sanitizeCameraMode(config.mode || getDefaultModeForProfile(profile));
+
+  if (!options.preservePairingLink && profile === DEFAULT_CAMERA_STREAM_PROFILE && mode === DEFAULT_CAMERA_STREAM_MODE) {
+    return sanitizedCameraUrl;
+  }
+
+  return buildCameraPairingUrl(sanitizedCameraUrl, BRAVE_PAWS_PAIRING_URL, { profile, mode });
+}
+
+export function normalizeCameraUrlValue(value: string): string {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  let preservePairingLink = false;
+
+  try {
+    const url = new URL(trimmed);
+    preservePairingLink = url.searchParams.has(CAMERA_URL_QUERY_PARAM);
+  } catch {
+    preservePairingLink = false;
+  }
+
+  return serializeCameraLaunchConfig(extractCameraLaunchConfig(value), { preservePairingLink });
 }
 
 export function sanitizeCameraUrl(value: string): string {
@@ -164,8 +194,19 @@ export function buildCameraPairingUrl(
 
 export function getCameraUrlFromSearch(search: string): string {
   const params = new URLSearchParams(search);
-  const cameraUrl = sanitizeCameraUrl(params.get(CAMERA_URL_QUERY_PARAM) || '');
-  return cameraUrl;
+  const cameraUrl = params.get(CAMERA_URL_QUERY_PARAM) || '';
+  const profileParam = params.get(CAMERA_PROFILE_QUERY_PARAM) || '';
+  const modeParam = params.get(CAMERA_MODE_QUERY_PARAM) || '';
+  const profile: CameraStreamProfile | undefined = profileParam
+    ? sanitizeCameraProfile(profileParam)
+    : undefined;
+
+  return normalizeCameraUrlValue(
+    buildCameraPairingUrl(cameraUrl, BRAVE_PAWS_PAIRING_URL, {
+      profile,
+      mode: modeParam || undefined,
+    }),
+  );
 }
 
 export function getCameraUrlValidationMessage(value: string): string {
@@ -174,6 +215,6 @@ export function getCameraUrlValidationMessage(value: string): string {
   }
 
   return isCameraUrlValid(value)
-    ? 'Camera URL looks good. Brave Paws will use it for remote preview.'
-    : 'Use the simplified Brave Paws camera URL, or http only for localhost testing.';
+    ? 'Camera link looks good. Brave Paws will use it for remote preview.'
+    : 'Use the Brave Paws pairing link, or http only for localhost testing.';
 }

--- a/apps/brave-paws-app/tests/camera-link-ui.test.js
+++ b/apps/brave-paws-app/tests/camera-link-ui.test.js
@@ -8,7 +8,7 @@ test('SessionConfig and ActiveSession use the shared camera link input', () => {
   const activeSession = readFileSync(resolve(process.cwd(), 'src/components/ActiveSession.tsx'), 'utf8');
 
   assert.match(sessionConfig, /CameraLinkInput/);
-  assert.match(sessionConfig, /simplified camera URL/i);
+  assert.match(sessionConfig, /full pairing link/i);
   assert.match(activeSession, /CameraLinkInput/);
   assert.match(activeSession, /Disconnect/);
   assert.match(activeSession, /Reconnect/);
@@ -17,7 +17,7 @@ test('SessionConfig and ActiveSession use the shared camera link input', () => {
   assert.match(activeSession, /Paste a camera URL to start the live preview/);
 });
 
-test('shared camera link input supports simplified camera URL entry', () => {
+test('shared camera link input supports pairing-link or direct camera URL entry', () => {
   const cameraLinkInput = readFileSync(resolve(process.cwd(), 'src/components/CameraLinkInput.tsx'), 'utf8');
 
   assert.match(cameraLinkInput, /Scan QR Code/);

--- a/apps/brave-paws-app/tests/camera-url.test.ts
+++ b/apps/brave-paws-app/tests/camera-url.test.ts
@@ -72,29 +72,29 @@ test('buildCameraPairingUrl encodes the cloudflare link into the Brave Paws URL'
   );
 });
 
-test('normalizeCameraUrlValue simplifies Brave Paws pairing links to the direct camera URL', () => {
+test('normalizeCameraUrlValue preserves Brave Paws pairing links so profile metadata survives scanning', () => {
   assert.equal(
     normalizeCameraUrlValue(`${BRAVE_PAWS_PAIRING_URL}?${CAMERA_URL_QUERY_PARAM}=https%3A%2F%2Fdemo.trycloudflare.com&${CAMERA_PROFILE_QUERY_PARAM}=remote-low-latency&${CAMERA_MODE_QUERY_PARAM}=mse%2Cmp4%2Cmjpeg`),
-    'https://demo.trycloudflare.com',
+    `${BRAVE_PAWS_PAIRING_URL}?${CAMERA_URL_QUERY_PARAM}=https%3A%2F%2Fdemo.trycloudflare.com&${CAMERA_PROFILE_QUERY_PARAM}=remote-low-latency&${CAMERA_MODE_QUERY_PARAM}=mse%2Cmp4%2Cmjpeg`,
   );
 });
 
-test('getCameraUrlFromSearch extracts and sanitizes the deep-link query parameter', () => {
+test('getCameraUrlFromSearch preserves pairing metadata from the deep-link query parameters', () => {
   assert.equal(
     getCameraUrlFromSearch(`?cameraUrl=https%3A%2F%2Fdemo.trycloudflare.com%2F&${CAMERA_PROFILE_QUERY_PARAM}=remote-low-latency&${CAMERA_MODE_QUERY_PARAM}=mse%2Cmp4%2Cmjpeg`),
-    'https://demo.trycloudflare.com',
+    `${BRAVE_PAWS_PAIRING_URL}?${CAMERA_URL_QUERY_PARAM}=https%3A%2F%2Fdemo.trycloudflare.com&${CAMERA_PROFILE_QUERY_PARAM}=remote-low-latency&${CAMERA_MODE_QUERY_PARAM}=mse%2Cmp4%2Cmjpeg`,
   );
 });
 
 test('getCameraUrlFromSearch sanitizes invalid remote profile values to the default low-latency profile', () => {
   assert.equal(
     getCameraUrlFromSearch(`?cameraUrl=https%3A%2F%2Fdemo.trycloudflare.com&${CAMERA_PROFILE_QUERY_PARAM}=definitely-invalid-profile`),
-    'https://demo.trycloudflare.com',
+    `${BRAVE_PAWS_PAIRING_URL}?${CAMERA_URL_QUERY_PARAM}=https%3A%2F%2Fdemo.trycloudflare.com&${CAMERA_PROFILE_QUERY_PARAM}=remote-low-latency&${CAMERA_MODE_QUERY_PARAM}=mse%2Cmp4%2Cmjpeg`,
   );
 });
 
 test('getCameraUrlValidationMessage explains empty and invalid values', () => {
   assert.match(getCameraUrlValidationMessage(''), /Brave Paws Streamer/i);
-  assert.match(getCameraUrlValidationMessage('invalid'), /camera url/i);
-  assert.match(getCameraUrlValidationMessage('https://demo.trycloudflare.com'), /camera url looks good/i);
+  assert.match(getCameraUrlValidationMessage('invalid'), /pairing link/i);
+  assert.match(getCameraUrlValidationMessage('https://demo.trycloudflare.com'), /camera link looks good/i);
 });


### PR DESCRIPTION
## Summary
- preserve Brave Paws pairing links instead of flattening them to a bare camera URL
- retain camera profile and mode metadata across QR scan, URL restore, and local storage persistence
- update app copy and tests to reflect pairing-link support

## Validation
- npm test
- npm run lint
- npm run build