### PR TITLE
feat: add safe pairing links for private camera access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+      - 'feature/*'
+      - 'feature/**'
 
 jobs:
   checks:

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ The intended architecture is now:
 
 - landing page at `/separation/`
 - app at `/separation/app/`
-- QUANTUM-hosted API at `/separation/api/`
+- self-hosted API at `/separation/api/`
 - same-origin picam proxy at `/separation/camera/`
-- Tailnet-first hosting on `quantum.tail080401.ts.net`
+- optional one-time pairing links at `/separation/app/?pairingToken=…`
+- public-safe defaults with environment-specific hosts supplied at deploy time
 
 ## Workspace commands
 
@@ -31,7 +32,8 @@ From the repo root:
 | `npm test` | Run app and server unit tests. |
 | `npm run lint` | Type-check app and server workspaces. |
 | `npm run test:e2e` | Run app Playwright tests. |
-| `npm run server:start` | Start the compiled QUANTUM server locally. |
+| `npm run server:start` | Start the compiled Brave Paws server locally. |
+| `npm run server:create-pairing -- --camera-url https://camera.example/live.stream` | Mint a one-time pairing URL when the pairing broker is enabled. |
 
 ## Workspace layout
 
@@ -50,6 +52,6 @@ apps/
 
 ## Notes
 
-- Browser-local persistence remains first-class, with automatic QUANTUM hydration/push around it.
-- Canonical synced data now lives under `Q:/fermi/brave-paws/data` on QUANTUM.
+- Browser-local persistence remains first-class, with automatic backend hydration/push around it.
+- Canonical synced data can live on the self-hosted server while public bundles stay free of private camera origins.
 - Public CD remains `main`-only; feature branches get CI without triggering deploy.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The intended architecture is now:
 - same-origin picam proxy at `/separation/camera/`
 - optional one-time pairing links at `/separation/app/?pairingToken=…`
 - public-safe defaults with environment-specific hosts supplied at deploy time
+- pairing creation only over explicit auth, with absolute links emitted only from configured public base URLs
 
 ## Workspace commands
 
@@ -54,4 +55,5 @@ apps/
 
 - Browser-local persistence remains first-class, with automatic backend hydration/push around it.
 - Canonical synced data can live on the self-hosted server while public bundles stay free of private camera origins.
+- Pairing records reject credential-bearing camera URLs so secrets do not leak into stored broker state or client responses.
 - Public CD remains `main`-only; feature branches get CI without triggering deploy.

--- a/apps/brave-paws-app/.env.example
+++ b/apps/brave-paws-app/.env.example
@@ -1,7 +1,9 @@
-# Optional canonical URLs for self-hosted / Tailnet deployments.
-VITE_BRAVE_PAWS_PUBLIC_BASE_URL="https://quantum.tail080401.ts.net/separation/"
-VITE_BRAVE_PAWS_APP_URL="https://quantum.tail080401.ts.net/separation/app/"
-VITE_BRAVE_PAWS_API_BASE_URL="https://quantum.tail080401.ts.net/separation/api/"
-VITE_BRAVE_PAWS_DEFAULT_CAMERA_URL="https://quantum.tail080401.ts.net/separation/camera/live.stream/"
+# Optional canonical URLs for public or self-hosted deployments.
+# Leave these unset to use same-origin /separation/* defaults.
+VITE_BRAVE_PAWS_PUBLIC_BASE_URL="https://brave-paws.example/separation/"
+VITE_BRAVE_PAWS_APP_URL="https://brave-paws.example/separation/app/"
+VITE_BRAVE_PAWS_API_BASE_URL="https://brave-paws.example/separation/api/"
+VITE_BRAVE_PAWS_DEFAULT_CAMERA_URL="https://brave-paws.example/separation/camera/live.stream/"
 
-# QUANTUM is the only user-facing sync target in v0.2.
+# Public deployments should not ship private camera origins directly.
+# Prefer one-time pairing links or a same-origin proxy path.

--- a/apps/brave-paws-app/README.md
+++ b/apps/brave-paws-app/README.md
@@ -29,10 +29,10 @@ Copy `.env.example` to `.env.local` and set values as needed.
 
 | Variable | Required | Description |
 |---|---|---|
-| `VITE_BRAVE_PAWS_PUBLIC_BASE_URL` | No | Canonical landing URL, usually the Tailnet `/separation/` route. |
-| `VITE_BRAVE_PAWS_APP_URL` | No | Canonical app URL for deep links and stream QR links. |
+| `VITE_BRAVE_PAWS_PUBLIC_BASE_URL` | No | Canonical landing URL, usually the public or self-hosted `/separation/` route. |
+| `VITE_BRAVE_PAWS_APP_URL` | No | Canonical app URL for pairing links and stream QR links. |
 | `VITE_BRAVE_PAWS_API_BASE_URL` | No | API base URL, typically `/separation/api/`. |
-| `VITE_BRAVE_PAWS_DEFAULT_CAMERA_URL` | No | Default same-origin picam stream URL shown by the QUANTUM shortcut. |
+| `VITE_BRAVE_PAWS_DEFAULT_CAMERA_URL` | No | Optional suggested same-origin picam stream URL shown by the quick-start button. |
 
 ## Related Docs
 

--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -13,6 +13,7 @@ import { StorageSync } from './components/StorageSync';
 import { useStorageSync } from './hooks/useStorageSync';
 import { exportToCSV, parseCSV } from './utils/export';
 import { CAMERA_URL_STORAGE_KEY, getCameraUrlFromSearch } from './utils/cameraUrl';
+import { PAIRING_TOKEN_QUERY_PARAM, resolveCameraUrlFromPairingToken } from './utils/pairingToken';
 import { installGlobalClientDiagnostics } from './utils/clientDiagnostics';
 import {
   ActiveSessionState,
@@ -46,18 +47,37 @@ export default function App() {
   useEffect(() => {
     installGlobalClientDiagnostics();
 
-    const pairedCameraUrl = getCameraUrlFromSearch(window.location.search);
-    if (!pairedCameraUrl) {
-      return;
-    }
+    const clearPairingSearchParams = () => {
+      const currentUrl = new URL(window.location.href);
+      currentUrl.searchParams.delete('cameraUrl');
+      currentUrl.searchParams.delete('cameraProfile');
+      currentUrl.searchParams.delete('cameraMode');
+      currentUrl.searchParams.delete(PAIRING_TOKEN_QUERY_PARAM);
+      window.history.replaceState({}, document.title, currentUrl.toString());
+    };
 
-    setCameraUrl((currentUrl) => (currentUrl === pairedCameraUrl ? currentUrl : pairedCameraUrl));
+    const applyPairingFromLocation = async () => {
+      const pairedCameraUrl = getCameraUrlFromSearch(window.location.search);
+      if (pairedCameraUrl) {
+        setCameraUrl((currentUrl) => (currentUrl === pairedCameraUrl ? currentUrl : pairedCameraUrl));
+        clearPairingSearchParams();
+        return;
+      }
 
-    const currentUrl = new URL(window.location.href);
-    currentUrl.searchParams.delete('cameraUrl');
-    currentUrl.searchParams.delete('cameraProfile');
-    currentUrl.searchParams.delete('cameraMode');
-    window.history.replaceState({}, document.title, currentUrl.toString());
+      try {
+        const tokenPairedCameraUrl = await resolveCameraUrlFromPairingToken(window.location.search);
+        if (!tokenPairedCameraUrl) {
+          return;
+        }
+
+        setCameraUrl((currentUrl) => (currentUrl === tokenPairedCameraUrl ? currentUrl : tokenPairedCameraUrl));
+        clearPairingSearchParams();
+      } catch (error) {
+        console.error('Failed to resolve pairing token', error);
+      }
+    };
+
+    void applyPairingFromLocation();
   }, []);
 
   // Keep cameraUrl in sync with local storage

--- a/apps/brave-paws-app/src/components/ActiveSession.tsx
+++ b/apps/brave-paws-app/src/components/ActiveSession.tsx
@@ -57,7 +57,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
   });
   const [previewReloadToken, setPreviewReloadToken] = useState(0);
   const [previewStatus, setPreviewStatus] = useState<'idle' | 'loading' | 'live' | 'degraded' | 'disconnected'>('idle');
-  const [previewStatusMessage, setPreviewStatusMessage] = useState('Paste a stream URL or use the QUANTUM picam shortcut to start the live preview.');
+  const [previewStatusMessage, setPreviewStatusMessage] = useState('Paste a stream URL, open a one-time pairing link, or use the suggested picam link to start the live preview.');
   const [isPreviewConnected, setIsPreviewConnected] = useState(() => isCameraUrlValid(cameraUrl));
   const [isPreviewMinimized, setIsPreviewMinimized] = useState(false);
   const lastLoggedPreviewStatusRef = useRef<string | null>(null);
@@ -255,7 +255,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
   useEffect(() => {
     if (!hasValidCameraUrl) {
       setPreviewStatus('idle');
-      setPreviewStatusMessage('Paste a stream URL or use the QUANTUM picam shortcut to start the live preview.');
+      setPreviewStatusMessage('Paste a stream URL, open a one-time pairing link, or use the suggested picam link to start the live preview.');
       return;
     }
 

--- a/apps/brave-paws-app/src/components/CameraLinkInput.tsx
+++ b/apps/brave-paws-app/src/components/CameraLinkInput.tsx
@@ -329,7 +329,7 @@ export function CameraLinkInput({
             </>
           ) : (
             <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-4 text-sm text-slate-500">
-              Live QR scanning is not available in this browser yet. Use manual entry or the QUANTUM picam shortcut instead.
+              Live QR scanning is not available in this browser yet. Use manual entry or the suggested picam link instead.
             </div>
           )}
 
@@ -367,8 +367,8 @@ export function CameraLinkInput({
           <div className="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-700 flex items-start gap-2">
             <Server size={16} className="shrink-0 mt-0.5" />
             <div>
-              <p className="font-medium">Quick start on QUANTUM</p>
-              <p className="mt-1 text-xs sm:text-sm">Use the built-in same-origin picam proxy when you want the easiest v0.2 setup.</p>
+              <p className="font-medium">Quick start on this deployment</p>
+              <p className="mt-1 text-xs sm:text-sm">Use the built-in suggested picam link when this deployment exposes a same-origin proxy.</p>
             </div>
           </div>
 
@@ -384,7 +384,7 @@ export function CameraLinkInput({
                   commitManualUrl();
                 }
               }}
-              placeholder="https://quantum.tail080401.ts.net/separation/camera/live.stream/"
+              placeholder="https://camera.example/live.stream/"
               className="w-full bg-white border border-slate-200 rounded-xl px-4 py-3 text-slate-700 outline-none focus:border-emerald-400 focus:ring-1 focus:ring-emerald-400 transition-all font-mono text-sm"
             />
             <p className={`${descriptionClass} ${isCameraUrlValid(manualUrl) ? 'text-emerald-700' : 'text-slate-500'}`}>
@@ -399,7 +399,7 @@ export function CameraLinkInput({
               className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-3 text-sm font-medium text-white hover:bg-emerald-600 transition-colors"
             >
               <Server size={16} />
-              Use QUANTUM picam
+              Use suggested picam
             </button>
             <button
               type="button"

--- a/apps/brave-paws-app/src/components/SessionConfig.tsx
+++ b/apps/brave-paws-app/src/components/SessionConfig.tsx
@@ -132,7 +132,7 @@ export function SessionConfig({ initialSession, cameraUrl = '', onCameraUrlChang
           <h2 className="text-lg font-bold text-slate-800">Camera Stream (Optional)</h2>
         </div>
         <p className="text-sm text-slate-500 mb-4">
-          Use the QUANTUM picam shortcut, scan a Brave Paws stream QR code, or paste the full stream link manually.
+          Use a one-time pairing link, scan a Brave Paws stream QR code, or paste the full stream link manually.
         </p>
         <CameraLinkInput
           cameraUrl={cameraUrl}

--- a/apps/brave-paws-app/src/utils/cameraUrl.ts
+++ b/apps/brave-paws-app/src/utils/cameraUrl.ts
@@ -205,7 +205,7 @@ export function getCameraUrlFromSearch(search: string): string {
 
 export function getCameraUrlValidationMessage(value: string): string {
   if (!value.trim()) {
-    return 'Add a stream URL, use the QUANTUM picam shortcut, or scan a Brave Paws stream QR code.';
+    return 'Add a stream URL, use the suggested picam link, or scan a Brave Paws stream QR code.';
   }
 
   return isCameraUrlValid(value)

--- a/apps/brave-paws-app/src/utils/pairingToken.ts
+++ b/apps/brave-paws-app/src/utils/pairingToken.ts
@@ -1,0 +1,44 @@
+import { getApiBaseUrl } from '../config';
+import { buildCameraPairingUrl, type CameraStreamProfile } from './cameraUrl';
+
+export const PAIRING_TOKEN_QUERY_PARAM = 'pairingToken';
+const PAIRING_TOKEN_PATTERN = /^[A-Za-z0-9_-]{10,200}$/;
+
+type PairingLookupResponse = {
+  cameraUrl?: string;
+  profile?: CameraStreamProfile;
+  mode?: string;
+};
+
+export function getPairingTokenFromSearch(search: string): string {
+  const token = new URLSearchParams(search).get(PAIRING_TOKEN_QUERY_PARAM)?.trim() || '';
+  return PAIRING_TOKEN_PATTERN.test(token) ? token : '';
+}
+
+export async function resolveCameraUrlFromPairingToken(
+  search: string,
+  options: {
+    apiBaseUrl?: string;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<string> {
+  const token = getPairingTokenFromSearch(search);
+  if (!token) {
+    return '';
+  }
+
+  const apiBaseUrl = options.apiBaseUrl || getApiBaseUrl();
+  const fetchImpl = options.fetchImpl || fetch;
+  const response = await fetchImpl(`${apiBaseUrl}pairings/${encodeURIComponent(token)}`);
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(detail || `Pairing lookup failed (${response.status})`);
+  }
+
+  const payload = await response.json() as PairingLookupResponse;
+  return buildCameraPairingUrl(payload.cameraUrl || '', undefined, {
+    profile: payload.profile,
+    mode: payload.mode,
+  });
+}

--- a/apps/brave-paws-app/tests/camera-link-ui.test.js
+++ b/apps/brave-paws-app/tests/camera-link-ui.test.js
@@ -8,21 +8,22 @@ test('SessionConfig and ActiveSession use the shared camera link input', () => {
   const activeSession = readFileSync(resolve(process.cwd(), 'src/components/ActiveSession.tsx'), 'utf8');
 
   assert.match(sessionConfig, /CameraLinkInput/);
-  assert.match(sessionConfig, /Use the QUANTUM picam shortcut/i);
+  assert.match(sessionConfig, /one-time pairing link/i);
   assert.match(activeSession, /CameraLinkInput/);
   assert.match(activeSession, /Disconnect/);
   assert.match(activeSession, /Reconnect/);
   assert.match(activeSession, /Minimise/);
   assert.match(activeSession, /Maximise/);
-  assert.match(activeSession, /Paste a stream URL or use the QUANTUM picam shortcut/i);
+  assert.match(activeSession, /one-time pairing link/i);
+  assert.match(activeSession, /suggested picam link/i);
 });
 
-test('shared camera link input supports QR, QUANTUM shortcut, and direct stream URL entry', () => {
+test('shared camera link input supports QR, suggested picam, and direct stream URL entry', () => {
   const cameraLinkInput = readFileSync(resolve(process.cwd(), 'src/components/CameraLinkInput.tsx'), 'utf8');
 
   assert.match(cameraLinkInput, /Scan QR Code/);
-  assert.match(cameraLinkInput, /Use QUANTUM picam/);
+  assert.match(cameraLinkInput, /Use suggested picam/);
   assert.match(cameraLinkInput, /Stream URL/);
-  assert.match(cameraLinkInput, /https:\/\/quantum\.tail080401\.ts\.net\/separation\/camera\/live\.stream\//);
+  assert.match(cameraLinkInput, /https:\/\/camera\.example\/live\.stream\//);
   assert.match(cameraLinkInput, /Use Stream URL/);
 });

--- a/apps/brave-paws-app/tests/camera-url.test.ts
+++ b/apps/brave-paws-app/tests/camera-url.test.ts
@@ -18,8 +18,8 @@ import {
 
 test('sanitizeCameraUrl trims whitespace and preserves stream paths', () => {
   assert.equal(
-    sanitizeCameraUrl('  https://quantum.tail080401.ts.net/separation/camera/live.stream/  '),
-    'https://quantum.tail080401.ts.net/separation/camera/live.stream',
+    sanitizeCameraUrl('  https://camera.example/separation/camera/live.stream/  '),
+    'https://camera.example/separation/camera/live.stream',
   );
 });
 
@@ -93,7 +93,7 @@ test('getCameraUrlFromSearch sanitizes invalid remote profile values to the defa
 });
 
 test('getCameraUrlValidationMessage explains empty and invalid values', () => {
-  assert.match(getCameraUrlValidationMessage(''), /quantum picam shortcut/i);
+  assert.match(getCameraUrlValidationMessage(''), /suggested picam link/i);
   assert.match(getCameraUrlValidationMessage('invalid'), /stream link/i);
   assert.match(getCameraUrlValidationMessage('https://demo.example/live.stream'), /stream link looks good/i);
 });

--- a/apps/brave-paws-app/tests/pairing-token.test.ts
+++ b/apps/brave-paws-app/tests/pairing-token.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getPairingTokenFromSearch, resolveCameraUrlFromPairingToken } from '../src/utils/pairingToken.ts';
+
+test('getPairingTokenFromSearch returns safe opaque tokens only', () => {
+  assert.equal(getPairingTokenFromSearch('?pairingToken=abc_DEF-1234567890'), 'abc_DEF-1234567890');
+  assert.equal(getPairingTokenFromSearch('?pairingToken=bad%20token'), '');
+  assert.equal(getPairingTokenFromSearch('?cameraUrl=https%3A%2F%2Fdemo.example%2Flive.stream'), '');
+});
+
+test('resolveCameraUrlFromPairingToken exchanges a token for a cached Brave Paws launch URL', async () => {
+  const pairedUrl = await resolveCameraUrlFromPairingToken('?pairingToken=abc_DEF-1234567890', {
+    apiBaseUrl: 'https://brave-paws.example/separation/api/',
+    fetchImpl: async (input: string | URL | Request) => {
+      assert.equal(String(input), 'https://brave-paws.example/separation/api/pairings/abc_DEF-1234567890');
+      return new Response(JSON.stringify({
+        cameraUrl: 'https://private.example/live.stream',
+        profile: 'remote-low-latency',
+        mode: 'mse,mp4,mjpeg',
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  assert.match(pairedUrl, /cameraUrl=https%3A%2F%2Fprivate\.example%2Flive\.stream/);
+  assert.match(pairedUrl, /cameraProfile=remote-low-latency/);
+});

--- a/apps/brave-paws-landing/index.html
+++ b/apps/brave-paws-landing/index.html
@@ -6,7 +6,7 @@
     <title>Brave Paws</title>
     <meta
       name="description"
-      content="Brave Paws helps dog guardians plan separation-anxiety training with a local-first session tracker, a QUANTUM-hosted Tailnet backend, and direct picam playback."
+      content="Brave Paws helps dog guardians plan separation-anxiety training with a local-first session tracker, safe pairing links for private camera access, and direct picam playback."
     />
     <script type="module" src="./version.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -28,7 +28,7 @@
           <div>
             <h1>Thoughtful tools for gradual separation-anxiety training.</h1>
             <p class="hero-copy">
-              Brave Paws is now a Harvey-first, local-first setup: a session tracker for the plan, direct picam playback for live checking, and a QUANTUM-hosted Tailnet backend for inspectable sync.
+              Brave Paws is now a Harvey-first, local-first setup: a session tracker for the plan, direct picam playback for live checking, and a self-hosted backend that can pair a safe public frontend to a private camera path.
             </p>
             <div class="hero-actions">
               <a class="button button-primary" href="./app/">Open Brave Paws App</a>
@@ -96,7 +96,7 @@
               <li>Create varied session steps with short absences.</li>
               <li>Run sessions with a guided countdown and total training timer.</li>
               <li>Record calm, coping, or panicking outcomes with notes.</li>
-              <li>Review history, charts, CSV exports, and QUANTUM sync.</li>
+              <li>Review history, charts, CSV exports, and inspectable sync.</li>
             </ul>
             <a class="button button-primary" href="./app/">Go to the App</a>
           </article>
@@ -104,15 +104,15 @@
           <article class="panel product-panel tailnet-panel">
             <div class="section-heading compact">
               <p class="eyebrow">Brave Paws v0.2</p>
-              <h2>QUANTUM-hosted frontend, backend, and same-origin picam access.</h2>
+              <h2>Safe public frontend, private pairing links, and same-origin picam access.</h2>
             </div>
             <p>
-              v0.2 retires the old Brave Paws Streamer helper. QUANTUM now serves the landing page, app, API, and a same-origin camera path in front of picam so the app can stay HTTPS-friendly over Tailnet.
+              v0.2 retires the old Brave Paws Streamer helper. The frontend can stay public-safe by default, while pairing links and a same-origin camera path handle private picam access without embedding private origins in the bundle.
             </p>
             <div class="architecture-card card">
               <div>
-                <p class="label">Tailnet app</p>
-                <p class="mono">quantum.tail080401.ts.net/separation/</p>
+                <p class="label">Public-safe app</p>
+                <p class="mono">brave-paws.example/separation/app/?pairingToken=…</p>
               </div>
               <div class="architecture-arrow">↔</div>
               <div>
@@ -131,7 +131,7 @@
           </div>
           <div class="repo-row">
             <p>
-              Brave Paws is built as an open-source monorepo with the landing page, app, QUANTUM server, and deployment workflows in one place.
+              Brave Paws is built as an open-source monorepo with the landing page, app, self-hosted server, and deployment workflows in one place.
             </p>
             <a class="button button-secondary" href="https://github.com/harvey-cash/separation-tracker" target="_blank" rel="noopener noreferrer">
               View GitHub Repo

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -1,6 +1,6 @@
 # Brave Paws Server
 
-Brave Paws Server is the local-first QUANTUM backend for Brave Paws v0.2.
+Brave Paws Server is the local-first backend for Brave Paws v0.2.
 
 It serves three things from one localhost process:
 
@@ -15,6 +15,7 @@ It serves three things from one localhost process:
 | `npm run dev` | Run the server in watch mode. |
 | `npm run build` | Compile the TypeScript server to `dist/`. |
 | `npm run start` | Start the compiled server. |
+| `npm run create-pairing -- --camera-url https://camera.example/live.stream` | Mint a one-time pairing URL when the pairing broker is enabled. |
 | `npm test` | Run the server test suite. |
 
 ## Environment
@@ -23,11 +24,15 @@ It serves three things from one localhost process:
 | --- | --- | --- |
 | `BRAVE_PAWS_HOST` | `127.0.0.1` | Bind host for the local server |
 | `BRAVE_PAWS_PORT` | `4310` | Bind port for the local server |
-| `BRAVE_PAWS_PUBLIC_BASE_URL` | unset | Canonical external base URL for docs / logs |
-| `BRAVE_PAWS_DATA_DIR` | `var/brave-paws` in the repo | Session storage directory (live QUANTUM deploy uses `/mnt/q/fermi/brave-paws/data`) |
+| `BRAVE_PAWS_PUBLIC_BASE_URL` | unset | Canonical external base URL used for logs and pairing URLs |
+| `BRAVE_PAWS_DATA_DIR` | `var/brave-paws` in the repo | Session storage directory |
 | `BRAVE_PAWS_AUTH_TOKEN` | unset | Optional token expected in `x-brave-paws-token` for write requests |
+| `BRAVE_PAWS_ENABLE_PAIRING` | `false` | Enables the opaque one-time pairing broker |
+| `BRAVE_PAWS_PAIRING_STORE_FILE` | `<data dir>/pairings.json` | Optional override for pairing-token storage |
 | `BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL` | `http://127.0.0.1:18888/` | Upstream picam / MediaMTX root that gets proxied under `/separation/camera/` |
 
 ## Storage
 
 Session data is stored as pretty JSON in `sessions.json` and mirrored to `brave_paws_sessions.csv` in the same directory so it stays easy to inspect, back up, and seed from a manual CSV drop.
+
+When pairing is enabled, opaque one-time camera pairing records are stored separately in `pairings.json`. Those links are meant to bootstrap a browser once; after the app resolves a token, it caches the resulting camera link locally and the token cannot be reused.

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -26,7 +26,7 @@ It serves three things from one localhost process:
 | `BRAVE_PAWS_PORT` | `4310` | Bind port for the local server |
 | `BRAVE_PAWS_PUBLIC_BASE_URL` | unset | Canonical external base URL used for logs and pairing URLs |
 | `BRAVE_PAWS_DATA_DIR` | `var/brave-paws` in the repo | Session storage directory |
-| `BRAVE_PAWS_AUTH_TOKEN` | unset | Optional token expected in `x-brave-paws-token` for write requests |
+| `BRAVE_PAWS_AUTH_TOKEN` | unset | Token expected in `x-brave-paws-token` for write requests; required before the HTTP pairing-creation endpoint will mint links |
 | `BRAVE_PAWS_ENABLE_PAIRING` | `false` | Enables the opaque one-time pairing broker |
 | `BRAVE_PAWS_PAIRING_STORE_FILE` | `<data dir>/pairings.json` | Optional override for pairing-token storage |
 | `BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL` | `http://127.0.0.1:18888/` | Upstream picam / MediaMTX root that gets proxied under `/separation/camera/` |
@@ -36,3 +36,9 @@ It serves three things from one localhost process:
 Session data is stored as pretty JSON in `sessions.json` and mirrored to `brave_paws_sessions.csv` in the same directory so it stays easy to inspect, back up, and seed from a manual CSV drop.
 
 When pairing is enabled, opaque one-time camera pairing records are stored separately in `pairings.json`. Those links are meant to bootstrap a browser once; after the app resolves a token, it caches the resulting camera link locally and the token cannot be reused.
+
+## Pairing safety notes
+
+- `POST /separation/api/pairings` stays disabled until `BRAVE_PAWS_AUTH_TOKEN` is configured, so enabling pairing does not silently create a public write endpoint.
+- Absolute `pairingUrl` values are only returned when `BRAVE_PAWS_PUBLIC_BASE_URL` is configured. Otherwise the server can still mint tokens, but callers must construct the final browser URL themselves.
+- Camera URLs with embedded credentials are rejected so secrets do not land in `pairings.json` or pairing responses.

--- a/apps/brave-paws-server/package.json
+++ b/apps/brave-paws-server/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "lint": "tsc --noEmit -p tsconfig.json",
     "start": "node dist/server.js",
+    "create-pairing": "tsx src/createPairing.ts",
     "test": "tsx --test tests/*.test.ts",
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\""
   },

--- a/apps/brave-paws-server/src/config.ts
+++ b/apps/brave-paws-server/src/config.ts
@@ -43,6 +43,8 @@ export type BravePawsServerConfig = {
   appDistDir: string;
   dataDir: string;
   dataFilePath: string;
+  pairingStoreFilePath: string;
+  pairingEnabled: boolean;
   cameraUpstreamBaseUrl: string;
   authToken: string | null;
 };
@@ -68,6 +70,8 @@ export function resolveConfig(env = process.env): BravePawsServerConfig {
     appDistDir: path.resolve(env.BRAVE_PAWS_APP_DIST_DIR || path.join(repoRoot, 'apps', 'brave-paws-app', 'dist')),
     dataDir,
     dataFilePath: path.join(dataDir, 'sessions.json'),
+    pairingStoreFilePath: path.resolve(env.BRAVE_PAWS_PAIRING_STORE_FILE || path.join(dataDir, 'pairings.json')),
+    pairingEnabled: env.BRAVE_PAWS_ENABLE_PAIRING === 'true',
     cameraUpstreamBaseUrl: (env.BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL || 'http://127.0.0.1:18888/').replace(/\/?$/, '/'),
     authToken: env.BRAVE_PAWS_AUTH_TOKEN || null,
   };

--- a/apps/brave-paws-server/src/createPairing.ts
+++ b/apps/brave-paws-server/src/createPairing.ts
@@ -1,0 +1,60 @@
+import {
+  buildPairingAppUrl,
+  createPairing,
+  DEFAULT_CAMERA_STREAM_MODE,
+  DEFAULT_CAMERA_STREAM_PROFILE,
+  type CameraStreamProfile,
+} from './pairings.js';
+import { resolveConfig } from './config.js';
+
+function readFlagValue(args: string[], flag: string): string | undefined {
+  const index = args.findIndex((entry) => entry === flag);
+  if (index < 0) {
+    return undefined;
+  }
+
+  return args[index + 1];
+}
+
+async function main() {
+  const config = resolveConfig();
+  const args = process.argv.slice(2);
+  const cameraUrl = readFlagValue(args, '--camera-url') || args[0];
+
+  if (!cameraUrl) {
+    console.error('Usage: npm run create-pairing --workspace brave-paws-server -- --camera-url https://camera.example/live.stream');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!config.pairingEnabled) {
+    console.error('Pairing broker is disabled. Set BRAVE_PAWS_ENABLE_PAIRING=true before creating pairing links.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const profileArg = readFlagValue(args, '--profile');
+  const profile: CameraStreamProfile = profileArg === 'local-quality' || profileArg === 'remote-low-latency'
+    ? profileArg
+    : DEFAULT_CAMERA_STREAM_PROFILE;
+  const mode = readFlagValue(args, '--mode') || DEFAULT_CAMERA_STREAM_MODE;
+  const ttlHoursRaw = readFlagValue(args, '--ttl-hours');
+  const ttlHours = ttlHoursRaw ? Number.parseInt(ttlHoursRaw, 10) : undefined;
+
+  const record = await createPairing(config.pairingStoreFilePath, { cameraUrl, profile, mode }, { ttlHours });
+
+  if (!config.publicBaseUrl) {
+    console.error('Pairing was created, but BRAVE_PAWS_PUBLIC_BASE_URL is not configured, so no absolute URL could be printed.');
+    console.error(`Token: ${record.token}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const pairingUrl = buildPairingAppUrl(config.publicBaseUrl, config.appBasePath, record.token);
+  console.log(pairingUrl);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/apps/brave-paws-server/src/createPairing.ts
+++ b/apps/brave-paws-server/src/createPairing.ts
@@ -46,8 +46,7 @@ async function main() {
 
   if (!config.publicBaseUrl) {
     console.error('Pairing was created, but BRAVE_PAWS_PUBLIC_BASE_URL is not configured, so no absolute URL could be printed.');
-    console.error(`Token: ${record.token}`);
-    process.exitCode = 1;
+    console.log(record.token);
     return;
   }
 

--- a/apps/brave-paws-server/src/createPairing.ts
+++ b/apps/brave-paws-server/src/createPairing.ts
@@ -22,7 +22,8 @@ async function main() {
   const cameraUrl = readFlagValue(args, '--camera-url') || args[0];
 
   if (!cameraUrl) {
-    console.error('Usage: npm run create-pairing --workspace brave-paws-server -- --camera-url https://camera.example/live.stream');
+    console.error('Usage: npm run create-pairing -- --camera-url https://camera.example/live.stream');
+    console.error('   or: npm run server:create-pairing -- --camera-url https://camera.example/live.stream');
     process.exitCode = 1;
     return;
   }

--- a/apps/brave-paws-server/src/pairings.ts
+++ b/apps/brave-paws-server/src/pairings.ts
@@ -1,0 +1,234 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const PAIRING_TOKEN_QUERY_PARAM = 'pairingToken';
+export const DEFAULT_CAMERA_STREAM_PROFILE = 'remote-low-latency';
+export const DEFAULT_CAMERA_STREAM_MODE = 'mse,mp4,mjpeg';
+const DEFAULT_PAIRING_TTL_HOURS = 24 * 7;
+const PRUNE_CONSUMED_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+const ALLOWED_CAMERA_STREAM_MODES = new Set(['webrtc', 'webrtc/tcp', 'mse', 'hls', 'mp4', 'mjpeg']);
+
+export type CameraStreamProfile = 'local-quality' | 'remote-low-latency';
+
+export type CameraLaunchConfig = {
+  cameraUrl: string;
+  profile: CameraStreamProfile;
+  mode: string;
+};
+
+export type PairingRecord = {
+  token: string;
+  createdAt: string;
+  expiresAt: string | null;
+  consumedAt: string | null;
+  launchConfig: CameraLaunchConfig;
+};
+
+type PairingStore = {
+  updatedAt: string | null;
+  pairings: PairingRecord[];
+};
+
+const EMPTY_PAIRING_STORE: PairingStore = {
+  updatedAt: null,
+  pairings: [],
+};
+
+function sanitizeCameraUrl(value: string): string {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1';
+    const hasValidProtocol = url.protocol === 'https:' || (isLocalhost && url.protocol === 'http:');
+
+    if (!hasValidProtocol) {
+      return '';
+    }
+
+    url.pathname = url.pathname.replace(/\/+$/, '') || '/';
+    return url.toString().replace(/\/+$/, (match, offset, fullValue) => (fullValue.endsWith('/') ? '/' : ''));
+  } catch {
+    return '';
+  }
+}
+
+function sanitizeCameraProfile(value: string): CameraStreamProfile {
+  if (value === 'local-quality' || value === 'remote-low-latency') {
+    return value;
+  }
+
+  return DEFAULT_CAMERA_STREAM_PROFILE;
+}
+
+function sanitizeCameraMode(value: string): string {
+  const normalized = value
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => ALLOWED_CAMERA_STREAM_MODES.has(entry));
+
+  if (!normalized.length) {
+    return DEFAULT_CAMERA_STREAM_MODE;
+  }
+
+  return Array.from(new Set(normalized)).join(',');
+}
+
+export function normalizeCameraLaunchConfig(candidate: Partial<CameraLaunchConfig>): CameraLaunchConfig | null {
+  const cameraUrl = sanitizeCameraUrl(candidate.cameraUrl || '');
+  if (!cameraUrl) {
+    return null;
+  }
+
+  return {
+    cameraUrl,
+    profile: sanitizeCameraProfile(candidate.profile || DEFAULT_CAMERA_STREAM_PROFILE),
+    mode: sanitizeCameraMode(candidate.mode || DEFAULT_CAMERA_STREAM_MODE),
+  };
+}
+
+async function ensureParentDirectory(filePath: string) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function readPairingStore(filePath: string): Promise<PairingStore> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<PairingStore>;
+    const pairings = Array.isArray(parsed.pairings)
+      ? parsed.pairings
+        .map((entry) => {
+          if (!entry || typeof entry !== 'object') {
+            return null;
+          }
+
+          const record = entry as Partial<PairingRecord> & { launchConfig?: Partial<CameraLaunchConfig> };
+          if (typeof record.token !== 'string' || !record.token) {
+            return null;
+          }
+
+          const launchConfig = normalizeCameraLaunchConfig(record.launchConfig || {});
+          if (!launchConfig) {
+            return null;
+          }
+
+          return {
+            token: record.token,
+            createdAt: typeof record.createdAt === 'string' ? record.createdAt : new Date(0).toISOString(),
+            expiresAt: typeof record.expiresAt === 'string' ? record.expiresAt : null,
+            consumedAt: typeof record.consumedAt === 'string' ? record.consumedAt : null,
+            launchConfig,
+          } satisfies PairingRecord;
+        })
+        .filter((entry): entry is PairingRecord => Boolean(entry))
+      : [];
+
+    return {
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : null,
+      pairings,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ...EMPTY_PAIRING_STORE };
+    }
+
+    throw error;
+  }
+}
+
+function isExpired(record: PairingRecord, nowMs = Date.now()) {
+  return Boolean(record.expiresAt && Date.parse(record.expiresAt) <= nowMs);
+}
+
+function prunePairings(pairings: PairingRecord[], nowMs = Date.now()) {
+  return pairings.filter((entry) => {
+    if (isExpired(entry, nowMs)) {
+      return false;
+    }
+
+    if (entry.consumedAt) {
+      return nowMs - Date.parse(entry.consumedAt) <= PRUNE_CONSUMED_AFTER_MS;
+    }
+
+    return true;
+  });
+}
+
+async function writePairingStore(filePath: string, pairings: PairingRecord[]): Promise<PairingStore> {
+  await ensureParentDirectory(filePath);
+
+  const payload: PairingStore = {
+    updatedAt: new Date().toISOString(),
+    pairings: prunePairings(pairings),
+  };
+
+  await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return payload;
+}
+
+export async function createPairing(
+  filePath: string,
+  candidate: Partial<CameraLaunchConfig>,
+  options: { ttlHours?: number } = {},
+): Promise<PairingRecord> {
+  const launchConfig = normalizeCameraLaunchConfig(candidate);
+  if (!launchConfig) {
+    throw new Error('A valid https:// camera URL is required for pairing creation');
+  }
+
+  const store = await readPairingStore(filePath);
+  const ttlHours = Number.isFinite(options.ttlHours) ? Math.max(1, Math.trunc(options.ttlHours as number)) : DEFAULT_PAIRING_TTL_HOURS;
+  const createdAt = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + (ttlHours * 60 * 60 * 1000)).toISOString();
+
+  const record: PairingRecord = {
+    token: crypto.randomBytes(18).toString('base64url'),
+    createdAt,
+    expiresAt,
+    consumedAt: null,
+    launchConfig,
+  };
+
+  await writePairingStore(filePath, [...store.pairings, record]);
+  return record;
+}
+
+export async function consumePairing(filePath: string, token: string): Promise<PairingRecord | null> {
+  const trimmedToken = token.trim();
+  if (!trimmedToken) {
+    return null;
+  }
+
+  const store = await readPairingStore(filePath);
+  const recordIndex = store.pairings.findIndex((entry) => entry.token === trimmedToken);
+  if (recordIndex < 0) {
+    return null;
+  }
+
+  const record = store.pairings[recordIndex];
+  if (!record || record.consumedAt || isExpired(record)) {
+    await writePairingStore(filePath, store.pairings);
+    return null;
+  }
+
+  const consumedRecord: PairingRecord = {
+    ...record,
+    consumedAt: new Date().toISOString(),
+  };
+
+  const nextPairings = [...store.pairings];
+  nextPairings[recordIndex] = consumedRecord;
+  await writePairingStore(filePath, nextPairings);
+  return consumedRecord;
+}
+
+export function buildPairingAppUrl(baseUrl: string, appBasePath: string, token: string): string {
+  const pairingUrl = new URL(appBasePath, baseUrl);
+  pairingUrl.searchParams.set(PAIRING_TOKEN_QUERY_PARAM, token);
+  return pairingUrl.toString();
+}

--- a/apps/brave-paws-server/src/pairings.ts
+++ b/apps/brave-paws-server/src/pairings.ts
@@ -8,7 +8,7 @@ export const DEFAULT_CAMERA_STREAM_MODE = 'mse,mp4,mjpeg';
 const DEFAULT_PAIRING_TTL_HOURS = 24 * 7;
 const PRUNE_CONSUMED_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 const ALLOWED_CAMERA_STREAM_MODES = new Set(['webrtc', 'webrtc/tcp', 'mse', 'hls', 'mp4', 'mjpeg']);
-const PAIRING_TOKEN_PATTERN = /^[A-Za-z0-9_-]{10,}$/;
+const PAIRING_TOKEN_PATTERN = /^[A-Za-z0-9_-]{10,200}$/;
 const pairingStoreLocks = new Map<string, Promise<void>>();
 
 export type CameraStreamProfile = 'local-quality' | 'remote-low-latency';

--- a/apps/brave-paws-server/src/pairings.ts
+++ b/apps/brave-paws-server/src/pairings.ts
@@ -8,6 +8,8 @@ export const DEFAULT_CAMERA_STREAM_MODE = 'mse,mp4,mjpeg';
 const DEFAULT_PAIRING_TTL_HOURS = 24 * 7;
 const PRUNE_CONSUMED_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 const ALLOWED_CAMERA_STREAM_MODES = new Set(['webrtc', 'webrtc/tcp', 'mse', 'hls', 'mp4', 'mjpeg']);
+const PAIRING_TOKEN_PATTERN = /^[A-Za-z0-9_-]{10,}$/;
+const pairingStoreLocks = new Map<string, Promise<void>>();
 
 export type CameraStreamProfile = 'local-quality' | 'remote-low-latency';
 
@@ -47,10 +49,11 @@ function sanitizeCameraUrl(value: string): string {
     const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1';
     const hasValidProtocol = url.protocol === 'https:' || (isLocalhost && url.protocol === 'http:');
 
-    if (!hasValidProtocol) {
+    if (!hasValidProtocol || url.username || url.password) {
       return '';
     }
 
+    url.hash = '';
     url.pathname = url.pathname.replace(/\/+$/, '') || '/';
     return url.toString().replace(/\/+$/, (match, offset, fullValue) => (fullValue.endsWith('/') ? '/' : ''));
   } catch {
@@ -167,8 +170,36 @@ async function writePairingStore(filePath: string, pairings: PairingRecord[]): P
     pairings: prunePairings(pairings),
   };
 
-  await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const tempFilePath = path.join(path.dirname(filePath), `${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  await fs.writeFile(tempFilePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  await fs.rename(tempFilePath, filePath);
   return payload;
+}
+
+async function withPairingStoreLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
+  const previous = pairingStoreLocks.get(filePath) || Promise.resolve();
+  let releaseLock = () => {};
+  const current = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+  const next = previous.catch(() => undefined).then(() => current);
+  pairingStoreLocks.set(filePath, next);
+
+  await previous.catch(() => undefined);
+
+  try {
+    return await operation();
+  } finally {
+    releaseLock();
+    if (pairingStoreLocks.get(filePath) === next) {
+      pairingStoreLocks.delete(filePath);
+    }
+  }
+}
+
+function normalizePairingToken(token: string): string {
+  const normalized = token.trim();
+  return PAIRING_TOKEN_PATTERN.test(normalized) ? normalized : '';
 }
 
 export async function createPairing(
@@ -178,53 +209,57 @@ export async function createPairing(
 ): Promise<PairingRecord> {
   const launchConfig = normalizeCameraLaunchConfig(candidate);
   if (!launchConfig) {
-    throw new Error('A valid https:// camera URL is required for pairing creation');
+    throw new Error('A valid https:// camera URL without embedded credentials is required for pairing creation');
   }
 
-  const store = await readPairingStore(filePath);
-  const ttlHours = Number.isFinite(options.ttlHours) ? Math.max(1, Math.trunc(options.ttlHours as number)) : DEFAULT_PAIRING_TTL_HOURS;
-  const createdAt = new Date().toISOString();
-  const expiresAt = new Date(Date.now() + (ttlHours * 60 * 60 * 1000)).toISOString();
+  return withPairingStoreLock(filePath, async () => {
+    const store = await readPairingStore(filePath);
+    const ttlHours = Number.isFinite(options.ttlHours) ? Math.max(1, Math.trunc(options.ttlHours as number)) : DEFAULT_PAIRING_TTL_HOURS;
+    const createdAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + (ttlHours * 60 * 60 * 1000)).toISOString();
 
-  const record: PairingRecord = {
-    token: crypto.randomBytes(18).toString('base64url'),
-    createdAt,
-    expiresAt,
-    consumedAt: null,
-    launchConfig,
-  };
+    const record: PairingRecord = {
+      token: crypto.randomBytes(18).toString('base64url'),
+      createdAt,
+      expiresAt,
+      consumedAt: null,
+      launchConfig,
+    };
 
-  await writePairingStore(filePath, [...store.pairings, record]);
-  return record;
+    await writePairingStore(filePath, [...store.pairings, record]);
+    return record;
+  });
 }
 
 export async function consumePairing(filePath: string, token: string): Promise<PairingRecord | null> {
-  const trimmedToken = token.trim();
-  if (!trimmedToken) {
+  const normalizedToken = normalizePairingToken(token);
+  if (!normalizedToken) {
     return null;
   }
 
-  const store = await readPairingStore(filePath);
-  const recordIndex = store.pairings.findIndex((entry) => entry.token === trimmedToken);
-  if (recordIndex < 0) {
-    return null;
-  }
+  return withPairingStoreLock(filePath, async () => {
+    const store = await readPairingStore(filePath);
+    const recordIndex = store.pairings.findIndex((entry) => entry.token === normalizedToken);
+    if (recordIndex < 0) {
+      return null;
+    }
 
-  const record = store.pairings[recordIndex];
-  if (!record || record.consumedAt || isExpired(record)) {
-    await writePairingStore(filePath, store.pairings);
-    return null;
-  }
+    const record = store.pairings[recordIndex];
+    if (!record || record.consumedAt || isExpired(record)) {
+      await writePairingStore(filePath, store.pairings);
+      return null;
+    }
 
-  const consumedRecord: PairingRecord = {
-    ...record,
-    consumedAt: new Date().toISOString(),
-  };
+    const consumedRecord: PairingRecord = {
+      ...record,
+      consumedAt: new Date().toISOString(),
+    };
 
-  const nextPairings = [...store.pairings];
-  nextPairings[recordIndex] = consumedRecord;
-  await writePairingStore(filePath, nextPairings);
-  return consumedRecord;
+    const nextPairings = [...store.pairings];
+    nextPairings[recordIndex] = consumedRecord;
+    await writePairingStore(filePath, nextPairings);
+    return consumedRecord;
+  });
 }
 
 export function buildPairingAppUrl(baseUrl: string, appBasePath: string, token: string): string {

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -120,19 +120,8 @@ function isWriteAuthorized(request: IncomingMessage, config: BravePawsServerConf
   return headerToken === config.authToken;
 }
 
-function getRequestOrigin(request: IncomingMessage, config: BravePawsServerConfig): string | null {
-  if (config.publicBaseUrl) {
-    return config.publicBaseUrl;
-  }
-
-  const host = request.headers.host;
-  if (!host) {
-    return null;
-  }
-
-  const forwardedProto = request.headers['x-forwarded-proto'];
-  const protocol = typeof forwardedProto === 'string' && forwardedProto ? forwardedProto.split(',')[0]?.trim() : 'http';
-  return `${protocol || 'http'}://${host}`;
+function getRequestOrigin(config: BravePawsServerConfig): string | null {
+  return config.publicBaseUrl;
 }
 
 function getMimeType(filePath: string): string {
@@ -531,6 +520,13 @@ async function handleApiRequest(
     }
 
     if (request.method === 'POST') {
+      if (!config.authToken) {
+        sendJson(response, 503, {
+          error: 'Pairing creation requires BRAVE_PAWS_AUTH_TOKEN to be configured',
+        });
+        return;
+      }
+
       if (!isWriteAuthorized(request, config)) {
         sendJson(response, 401, { error: 'Unauthorized' });
         return;
@@ -551,7 +547,7 @@ async function handleApiRequest(
           },
           { ttlHours: payload.ttlHours },
         );
-        const requestOrigin = getRequestOrigin(request, config);
+        const requestOrigin = getRequestOrigin(config);
         const pairingUrl = requestOrigin ? buildPairingAppUrl(requestOrigin, config.appBasePath, record.token) : null;
 
         sendJson(response, 201, {
@@ -577,7 +573,7 @@ async function handleApiRequest(
     }
 
     if (request.method === 'GET') {
-      const token = decodeURIComponent(pathname.slice(`${pairingCollectionPath}/`.length));
+      const token = pathname.slice(`${pairingCollectionPath}/`.length);
       const record = await consumePairing(config.pairingStoreFilePath, token);
 
       if (!record) {
@@ -703,11 +699,13 @@ export function createBravePawsServer(config = resolveConfig()) {
 
       notFound(response);
     } catch (error) {
-      sendText(
-        response,
-        500,
-        error instanceof Error ? error.stack || error.message : 'Unknown server error',
-      );
+      if (error instanceof TypeError) {
+        sendJson(response, 400, { error: 'Invalid request URL' });
+        return;
+      }
+
+      console.error('Brave Paws server request failed', error);
+      sendText(response, 500, 'Internal server error');
     }
   });
 
@@ -730,6 +728,12 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     console.log(`Session store: ${config.dataFilePath}`);
     if (config.pairingEnabled) {
       console.log(`Pairing broker: http://${config.host}:${config.port}${config.apiBasePath}pairings`);
+      if (!config.authToken) {
+        console.warn('Pairing creation over HTTP is disabled until BRAVE_PAWS_AUTH_TOKEN is configured.');
+      }
+      if (!config.publicBaseUrl) {
+        console.warn('Pairing tokens can still be minted, but absolute pairing URLs require BRAVE_PAWS_PUBLIC_BASE_URL.');
+      }
     }
   });
 }

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -5,6 +5,12 @@ import path from 'node:path';
 
 import { resolveConfig, type BravePawsServerConfig } from './config.js';
 import {
+  buildPairingAppUrl,
+  consumePairing,
+  createPairing,
+  PAIRING_TOKEN_QUERY_PARAM,
+} from './pairings.js';
+import {
   appendClientDiagnostic,
   readSessionStore,
   upsertSession,
@@ -112,6 +118,21 @@ function isWriteAuthorized(request: IncomingMessage, config: BravePawsServerConf
 
   const headerToken = request.headers['x-brave-paws-token'];
   return headerToken === config.authToken;
+}
+
+function getRequestOrigin(request: IncomingMessage, config: BravePawsServerConfig): string | null {
+  if (config.publicBaseUrl) {
+    return config.publicBaseUrl;
+  }
+
+  const host = request.headers.host;
+  if (!host) {
+    return null;
+  }
+
+  const forwardedProto = request.headers['x-forwarded-proto'];
+  const protocol = typeof forwardedProto === 'string' && forwardedProto ? forwardedProto.split(',')[0]?.trim() : 'http';
+  return `${protocol || 'http'}://${host}`;
 }
 
 function getMimeType(filePath: string): string {
@@ -432,6 +453,8 @@ async function handleApiRequest(
       apiBasePath: config.apiBasePath,
       cameraBasePath: config.cameraBasePath,
       clientDiagnosticsPath: config.clientDiagnosticsPath,
+      pairingEnabled: config.pairingEnabled,
+      pairingTokenQueryParam: PAIRING_TOKEN_QUERY_PARAM,
       sessionCount: store.sessions.length,
       updatedAt: store.updatedAt,
     });
@@ -442,6 +465,7 @@ async function handleApiRequest(
   const syncPullPath = `${config.apiBasePath}sync/pull`;
   const syncPushPath = `${config.apiBasePath}sync/push`;
   const clientDiagnosticsPath = config.clientDiagnosticsPath;
+  const pairingCollectionPath = `${config.apiBasePath}pairings`;
 
   if (request.method === 'GET' && pathname === sessionsCollectionPath) {
     const store = await readSessionStore(config.dataFilePath);
@@ -498,6 +522,78 @@ async function handleApiRequest(
       status: 'accepted',
     });
     return;
+  }
+
+  if (pathname === pairingCollectionPath) {
+    if (!config.pairingEnabled) {
+      notFound(response);
+      return;
+    }
+
+    if (request.method === 'POST') {
+      if (!isWriteAuthorized(request, config)) {
+        sendJson(response, 401, { error: 'Unauthorized' });
+        return;
+      }
+
+      const payload = await readJsonBody<{ cameraUrl?: string; profile?: string; mode?: string; ttlHours?: number }>(request);
+
+      try {
+        const record = await createPairing(
+          config.pairingStoreFilePath,
+          {
+            cameraUrl: payload.cameraUrl || '',
+            profile:
+              payload.profile === 'local-quality' || payload.profile === 'remote-low-latency'
+                ? payload.profile
+                : undefined,
+            mode: payload.mode,
+          },
+          { ttlHours: payload.ttlHours },
+        );
+        const requestOrigin = getRequestOrigin(request, config);
+        const pairingUrl = requestOrigin ? buildPairingAppUrl(requestOrigin, config.appBasePath, record.token) : null;
+
+        sendJson(response, 201, {
+          token: record.token,
+          pairingUrl,
+          expiresAt: record.expiresAt,
+          profile: record.launchConfig.profile,
+          mode: record.launchConfig.mode,
+        });
+      } catch (error) {
+        sendJson(response, 400, {
+          error: error instanceof Error ? error.message : 'Could not create pairing',
+        });
+      }
+      return;
+    }
+  }
+
+  if (pathname.startsWith(`${pairingCollectionPath}/`)) {
+    if (!config.pairingEnabled) {
+      notFound(response);
+      return;
+    }
+
+    if (request.method === 'GET') {
+      const token = decodeURIComponent(pathname.slice(`${pairingCollectionPath}/`.length));
+      const record = await consumePairing(config.pairingStoreFilePath, token);
+
+      if (!record) {
+        notFound(response, 'Pairing token not found or expired');
+        return;
+      }
+
+      sendJson(response, 200, {
+        cameraUrl: record.launchConfig.cameraUrl,
+        profile: record.launchConfig.profile,
+        mode: record.launchConfig.mode,
+        expiresAt: record.expiresAt,
+        consumedAt: record.consumedAt,
+      });
+      return;
+    }
   }
 
   if (pathname.startsWith(`${sessionsCollectionPath}/`)) {
@@ -632,5 +728,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     console.log(`API health: http://${config.host}:${config.port}${config.healthPath}`);
     console.log(`Camera proxy: http://${config.host}:${config.port}${config.cameraBasePath}live.stream/`);
     console.log(`Session store: ${config.dataFilePath}`);
+    if (config.pairingEnabled) {
+      console.log(`Pairing broker: http://${config.host}:${config.port}${config.apiBasePath}pairings`);
+    }
   });
 }

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -532,9 +532,8 @@ async function handleApiRequest(
         return;
       }
 
-      const payload = await readJsonBody<{ cameraUrl?: string; profile?: string; mode?: string; ttlHours?: number }>(request);
-
       try {
+        const payload = await readJsonBody<{ cameraUrl?: string; profile?: string; mode?: string; ttlHours?: number }>(request);
         const record = await createPairing(
           config.pairingStoreFilePath,
           {

--- a/apps/brave-paws-server/tests/create-pairing.test.ts
+++ b/apps/brave-paws-server/tests/create-pairing.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const workspaceDir = path.resolve(__dirname, '..');
+
+async function runCreatePairing(args: string[], env: NodeJS.ProcessEnv) {
+  return new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn('npm', ['run', 'create-pairing', '--', ...args], {
+      cwd: workspaceDir,
+      env: {
+        ...process.env,
+        ...env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+test('create-pairing CLI succeeds with token-only output when no public base URL is configured', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-create-pairing-cli-'));
+
+  try {
+    const result = await runCreatePairing([
+      '--camera-url',
+      'https://private.example/live.stream',
+    ], {
+      BRAVE_PAWS_ENABLE_PAIRING: 'true',
+      BRAVE_PAWS_DATA_DIR: tempDir,
+      BRAVE_PAWS_PUBLIC_BASE_URL: '',
+    });
+
+    assert.equal(result.code, 0);
+    assert.match(result.stderr, /no absolute URL could be printed/i);
+    const token = result.stdout.trim().split(/\r?\n/).at(-1) || '';
+    assert.match(token, /^[A-Za-z0-9_-]{10,200}$/);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/brave-paws-server/tests/pairings.test.ts
+++ b/apps/brave-paws-server/tests/pairings.test.ts
@@ -75,3 +75,21 @@ test('consumePairing only succeeds once under concurrent reads', async () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test('consumePairing rejects excessively long tokens', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-pairings-token-length-'));
+  const filePath = path.join(tempDir, 'pairings.json');
+
+  try {
+    const created = await createPairing(filePath, {
+      cameraUrl: 'https://private.example/live.stream',
+      profile: 'remote-low-latency',
+      mode: 'mse,mp4,mjpeg',
+    });
+
+    assert.equal(await consumePairing(filePath, `${created.token}${'a'.repeat(201)}`), null);
+    assert.ok(await consumePairing(filePath, created.token));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/brave-paws-server/tests/pairings.test.ts
+++ b/apps/brave-paws-server/tests/pairings.test.ts
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { consumePairing, createPairing } from '../src/pairings.ts';
+
+test('createPairing rejects camera URLs with embedded credentials', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-pairings-credentials-'));
+  const filePath = path.join(tempDir, 'pairings.json');
+
+  try {
+    await assert.rejects(
+      createPairing(filePath, {
+        cameraUrl: 'https://user:pass@private.example/live.stream',
+      }),
+      /without embedded credentials/,
+    );
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('createPairing preserves every token under concurrent creation', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-pairings-create-'));
+  const filePath = path.join(tempDir, 'pairings.json');
+
+  try {
+    const records = await Promise.all(
+      Array.from({ length: 20 }, () => createPairing(filePath, {
+        cameraUrl: 'https://private.example/live.stream',
+        profile: 'remote-low-latency',
+        mode: 'mse,mp4,mjpeg',
+      })),
+    );
+
+    const stored = JSON.parse(await fs.readFile(filePath, 'utf8')) as {
+      pairings: Array<{ token: string; launchConfig: { cameraUrl: string } }>;
+    };
+
+    assert.equal(records.length, 20);
+    assert.equal(stored.pairings.length, 20);
+    assert.equal(new Set(records.map((record) => record.token)).size, 20);
+    assert.equal(new Set(stored.pairings.map((record) => record.token)).size, 20);
+    assert.ok(stored.pairings.every((record) => record.launchConfig.cameraUrl === 'https://private.example/live.stream'));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('consumePairing only succeeds once under concurrent reads', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-pairings-consume-'));
+  const filePath = path.join(tempDir, 'pairings.json');
+
+  try {
+    const created = await createPairing(filePath, {
+      cameraUrl: 'https://private.example/live.stream',
+      profile: 'remote-low-latency',
+      mode: 'mse,mp4,mjpeg',
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => consumePairing(filePath, created.token)),
+    );
+
+    assert.equal(results.filter(Boolean).length, 1);
+
+    const stored = JSON.parse(await fs.readFile(filePath, 'utf8')) as {
+      pairings: Array<{ token: string; consumedAt: string | null }>;
+    };
+    const storedRecord = stored.pairings.find((record) => record.token === created.token);
+    assert.ok(storedRecord?.consumedAt);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -54,6 +54,8 @@ async function withFixtureServer(run: (context: { baseUrl: string; config: Brave
     appDistDir: appDir,
     dataDir,
     dataFilePath: path.join(dataDir, 'sessions.json'),
+    pairingStoreFilePath: path.join(dataDir, 'pairings.json'),
+    pairingEnabled: false,
     cameraUpstreamBaseUrl: `${upstreamBaseUrl}/`,
     authToken: null,
   };
@@ -204,7 +206,7 @@ test('client diagnostics endpoint appends sanitized frontend events to disk', as
         severity: 'error',
         message: 'Sync exploded',
         fingerprint: 'quantum-sync:error',
-        pageUrl: 'https://quantum.tail080401.ts.net:7447/separation/app/',
+        pageUrl: 'https://brave-paws.example/separation/app/',
         details: {
           stage: 'push',
           nested: {
@@ -232,7 +234,7 @@ test('client diagnostics endpoint appends sanitized frontend events to disk', as
     assert.equal(record.severity, 'error');
     assert.equal(record.message, 'Sync exploded');
     assert.equal(record.fingerprint, 'quantum-sync:error');
-    assert.equal(record.pageUrl, 'https://quantum.tail080401.ts.net:7447/separation/app/');
+    assert.equal(record.pageUrl, 'https://brave-paws.example/separation/app/');
     assert.equal(record.details.stage, 'push');
     assert.equal(record.details.nested.reason, 'timeout');
   });
@@ -269,6 +271,8 @@ test('client diagnostics endpoint requires auth when a token is configured', asy
     appDistDir: appDir,
     dataDir,
     dataFilePath: path.join(dataDir, 'sessions.json'),
+    pairingStoreFilePath: path.join(dataDir, 'pairings.json'),
+    pairingEnabled: false,
     cameraUpstreamBaseUrl: `${upstreamBaseUrl}/`,
     authToken: 'secret-token',
   };
@@ -293,6 +297,93 @@ test('client diagnostics endpoint requires auth when a token is configured', asy
       body: JSON.stringify({ category: 'frontend_error', severity: 'warn', message: 'allowed' }),
     });
     assert.equal(authorized.status, 202);
+  } finally {
+    await close(server);
+    await close(upstream);
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('pairing broker is disabled by default for public-safety', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await fetch(`${baseUrl}/separation/api/pairings`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cameraUrl: 'https://private.example/live.stream' }),
+    });
+
+    assert.equal(response.status, 404);
+  });
+});
+
+test('pairing broker creates one-time pairing URLs and consumes them once', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-server-pairings-'));
+  const landingDir = path.join(tempDir, 'landing');
+  const appDir = path.join(tempDir, 'app');
+  const dataDir = path.join(tempDir, 'data');
+  await fs.mkdir(landingDir, { recursive: true });
+  await fs.mkdir(appDir, { recursive: true });
+  await fs.mkdir(dataDir, { recursive: true });
+  await fs.writeFile(path.join(landingDir, 'index.html'), '<html><body>landing</body></html>');
+  await fs.writeFile(path.join(appDir, 'index.html'), '<html><body>app</body></html>');
+
+  const upstream = http.createServer((request, response) => {
+    response.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+    response.end(`camera:${request.url}`);
+  });
+  const upstreamBaseUrl = await listen(upstream);
+
+  const config: BravePawsServerConfig = {
+    host: '127.0.0.1',
+    port: 0,
+    publicBaseUrl: 'https://brave-paws.example/',
+    landingBasePath: '/separation/',
+    appBasePath: '/separation/app/',
+    apiBasePath: '/separation/api/',
+    cameraBasePath: '/separation/camera/',
+    healthPath: '/separation/api/health',
+    clientDiagnosticsPath: '/separation/api/client-diagnostics',
+    landingDistDir: landingDir,
+    appDistDir: appDir,
+    dataDir,
+    dataFilePath: path.join(dataDir, 'sessions.json'),
+    pairingStoreFilePath: path.join(dataDir, 'pairings.json'),
+    pairingEnabled: true,
+    cameraUpstreamBaseUrl: `${upstreamBaseUrl}/`,
+    authToken: 'secret-token',
+  };
+
+  const server = createBravePawsServer(config);
+  const baseUrl = await listen(server);
+
+  try {
+    const created = await fetch(`${baseUrl}/separation/api/pairings`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-brave-paws-token': 'secret-token',
+      },
+      body: JSON.stringify({
+        cameraUrl: 'https://private.example/live.stream/',
+        profile: 'remote-low-latency',
+        mode: 'mse,mp4,mjpeg',
+      }),
+    });
+    assert.equal(created.status, 201);
+
+    const createdPayload = await created.json() as { token: string; pairingUrl: string; expiresAt: string | null };
+    assert.match(createdPayload.token, /^[A-Za-z0-9_-]{10,}$/);
+    assert.equal(createdPayload.pairingUrl, `https://brave-paws.example/separation/app/?pairingToken=${createdPayload.token}`);
+    assert.ok(createdPayload.expiresAt);
+
+    const consumeResponse = await fetch(`${baseUrl}/separation/api/pairings/${createdPayload.token}`);
+    assert.equal(consumeResponse.status, 200);
+    const consumePayload = await consumeResponse.json() as { cameraUrl: string; consumedAt: string | null };
+    assert.equal(consumePayload.cameraUrl, 'https://private.example/live.stream');
+    assert.ok(consumePayload.consumedAt);
+
+    const secondConsume = await fetch(`${baseUrl}/separation/api/pairings/${createdPayload.token}`);
+    assert.equal(secondConsume.status, 404);
   } finally {
     await close(server);
     await close(upstream);

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -363,6 +363,25 @@ test('pairing broker requires BRAVE_PAWS_AUTH_TOKEN for HTTP pairing creation', 
   });
 });
 
+test('pairing broker returns 400 for malformed JSON bodies', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await fetch(`${baseUrl}/separation/api/pairings`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-brave-paws-token': 'secret-token',
+      },
+      body: '{"cameraUrl":',
+    });
+
+    assert.equal(response.status, 400);
+    assert.match(await response.text(), /Could not create pairing|JSON|Unexpected/i);
+  }, {
+    pairingEnabled: true,
+    authToken: 'secret-token',
+  });
+});
+
 test('pairing broker only returns absolute pairing URLs from BRAVE_PAWS_PUBLIC_BASE_URL', async () => {
   await withFixtureServer(async ({ baseUrl }) => {
     const response = await fetch(`${baseUrl}/separation/api/pairings`, {

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -22,7 +22,38 @@ async function close(server: http.Server) {
   await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
 }
 
-async function withFixtureServer(run: (context: { baseUrl: string; config: BravePawsServerConfig }) => Promise<void>) {
+async function requestRaw(baseUrl: string, requestPath: string) {
+  const url = new URL(baseUrl);
+
+  return new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
+    const request = http.request(
+      {
+        host: url.hostname,
+        port: url.port,
+        path: requestPath,
+        method: 'GET',
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+        response.on('end', () => {
+          resolve({
+            statusCode: response.statusCode || 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function withFixtureServer(
+  run: (context: { baseUrl: string; config: BravePawsServerConfig }) => Promise<void>,
+  configOverrides: Partial<BravePawsServerConfig> = {},
+) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-server-'));
   const landingDir = path.join(tempDir, 'landing');
   const appDir = path.join(tempDir, 'app');
@@ -58,6 +89,7 @@ async function withFixtureServer(run: (context: { baseUrl: string; config: Brave
     pairingEnabled: false,
     cameraUpstreamBaseUrl: `${upstreamBaseUrl}/`,
     authToken: null,
+    ...configOverrides,
   };
 
   const server = createBravePawsServer(config);
@@ -316,6 +348,43 @@ test('pairing broker is disabled by default for public-safety', async () => {
   });
 });
 
+test('pairing broker requires BRAVE_PAWS_AUTH_TOKEN for HTTP pairing creation', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await fetch(`${baseUrl}/separation/api/pairings`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cameraUrl: 'https://private.example/live.stream' }),
+    });
+
+    assert.equal(response.status, 503);
+    assert.match(await response.text(), /BRAVE_PAWS_AUTH_TOKEN/);
+  }, {
+    pairingEnabled: true,
+  });
+});
+
+test('pairing broker only returns absolute pairing URLs from BRAVE_PAWS_PUBLIC_BASE_URL', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await fetch(`${baseUrl}/separation/api/pairings`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-brave-paws-token': 'secret-token',
+        host: 'evil.example',
+        'x-forwarded-proto': 'https',
+      },
+      body: JSON.stringify({ cameraUrl: 'https://private.example/live.stream' }),
+    });
+
+    assert.equal(response.status, 201);
+    const payload = await response.json() as { pairingUrl: string | null };
+    assert.equal(payload.pairingUrl, null);
+  }, {
+    pairingEnabled: true,
+    authToken: 'secret-token',
+  });
+});
+
 test('pairing broker creates one-time pairing URLs and consumes them once', async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-server-pairings-'));
   const landingDir = path.join(tempDir, 'landing');
@@ -389,6 +458,18 @@ test('pairing broker creates one-time pairing URLs and consumes them once', asyn
     await close(upstream);
     await fs.rm(tempDir, { recursive: true, force: true });
   }
+});
+
+test('malformed pairing tokens do not trigger a server error or stack leak', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await requestRaw(baseUrl, '/separation/api/pairings/%ZZ');
+    assert.equal(response.statusCode, 404);
+    assert.match(response.body, /Pairing token not found or expired/);
+    assert.doesNotMatch(response.body, /TypeError|at createBravePawsServer/);
+  }, {
+    pairingEnabled: true,
+    authToken: 'secret-token',
+  });
 });
 
 test('serves landing and app static files from the configured paths', async () => {

--- a/deploy/systemd/brave-paws.service
+++ b/deploy/systemd/brave-paws.service
@@ -10,7 +10,7 @@ Group=harvey
 WorkingDirectory=/mnt/q/repos/separation-tracker
 Environment=BRAVE_PAWS_HOST=127.0.0.1
 Environment=BRAVE_PAWS_PORT=4310
-Environment=BRAVE_PAWS_PUBLIC_BASE_URL=https://quantum.tail080401.ts.net:7447
+Environment=BRAVE_PAWS_PUBLIC_BASE_URL=https://tailnet-host.example.ts.net:7447
 Environment="BRAVE_PAWS_DATA_DIR=/mnt/q/fermi/brave-paws/data"
 Environment=BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL=http://127.0.0.1:18888/
 ExecStart=/usr/bin/env npm --prefix /mnt/q/repos/separation-tracker run server:start

--- a/docs/plans/2026-05-03-brave-paws-pairing-slice.md
+++ b/docs/plans/2026-05-03-brave-paws-pairing-slice.md
@@ -1,0 +1,16 @@
+# Brave Paws pairing slice — implementation plan
+
+## Current state
+- The app already supports deep links that embed the raw `cameraUrl` in the query string and then caches the chosen stream in browser storage.
+- Runtime defaults fall back to same-origin paths, but the app copy/examples still assume a QUANTUM-specific shortcut and direct stream URL.
+- The server exposes sync + camera proxy endpoints, but there is no broker for opaque pairing links.
+
+## Smallest safe next step
+1. Add a server-side pairing broker that stores an opaque token -> camera launch config mapping and returns a one-time pairing URL.
+2. Make the broker opt-in and auth-protected for writes so public deployments stay safe by default.
+3. Teach the app to resolve `pairingToken` links through the API, cache the resolved stream locally, and then strip the token from the URL.
+4. Remove private-host defaults from app examples/tests/copy so the public frontend bundle does not ship QUANTUM-specific URLs by default.
+5. Add targeted app/server tests for token resolution, config safety, and pairing creation/consumption.
+
+## Follow-up after this slice
+- If Harvey wants truly public `harvey.cash` pairing into a private QUANTUM backend, add a dedicated public broker deployment that can mint/consume tokens without exposing the private origin itself.

--- a/docs/plans/2026-05-03-brave-paws-v0.2-local-tailnet-executive-plan.md
+++ b/docs/plans/2026-05-03-brave-paws-v0.2-local-tailnet-executive-plan.md
@@ -217,9 +217,9 @@ This keeps v0.2 coherent and makes local staging much simpler.
 
 Recommended local path layout:
 
-- `https://quantum.tail080401.ts.net/separation/`
-- `https://quantum.tail080401.ts.net/separation/app/`
-- `https://quantum.tail080401.ts.net/separation/api/...`
+- `https://tailnet-host.example.ts.net/separation/`
+- `https://tailnet-host.example.ts.net/separation/app/`
+- `https://tailnet-host.example.ts.net/separation/api/...`
 - optional future stream-facing path(s) under the same origin if needed, but **no separate streamer app for v0.2**
 
 Reason:
@@ -236,7 +236,7 @@ Reason:
 Tailnet-only for now.
 
 Recommended canonical origin:
-- `https://quantum.tail080401.ts.net`
+- `https://tailnet-host.example.ts.net`
 
 Do not expose publicly.
 Do not wire this into `harvey.cash` yet.

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -36,7 +36,7 @@ Default bind:
 | --- | --- |
 | `BRAVE_PAWS_PUBLIC_BASE_URL` | `https://tailnet-host.example.ts.net` |
 | `BRAVE_PAWS_DATA_DIR` | `/mnt/q/fermi/brave-paws/data` |
-| `BRAVE_PAWS_AUTH_TOKEN` | `replace-with-shared-secret-if-needed` |
+| `BRAVE_PAWS_AUTH_TOKEN` | `replace-with-long-random-secret-before-enabling-pairing` |
 | `BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL` | `http://127.0.0.1:18888/` |
 
 ## Session storage
@@ -69,4 +69,5 @@ If Harvey drops a fresher `brave_paws_sessions.csv` into the data folder, the se
 ## Notes
 
 - The camera path is a same-origin proxy in front of picam / MediaMTX, and directory-style preview URLs such as `/separation/camera/live.stream` are redirected to the working trailing-slash preview page automatically.
+- If you enable pairing, also set `BRAVE_PAWS_AUTH_TOKEN`; otherwise the HTTP pairing-creation endpoint stays disabled on purpose and only the local CLI can mint tokens.
 - Local browser persistence still exists in the app; QUANTUM hydrates on open and automatically pushes changes back to the inspectable QUANTUM data folder.

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -13,10 +13,10 @@ The intended public-facing origin for v0.2 is Tailnet-only.
 
 If `:443` is already occupied by public Funnel-backed routes on QUANTUM, expose Brave Paws on a dedicated Tailnet-only HTTPS port instead. The current live deployment target is:
 
-- `https://quantum.tail080401.ts.net:7447/separation/`
-- `https://quantum.tail080401.ts.net:7447/separation/app/`
-- `https://quantum.tail080401.ts.net:7447/separation/api/health`
-- `https://quantum.tail080401.ts.net:7447/separation/camera/live.stream/`
+- `https://tailnet-host.example.ts.net:7447/separation/`
+- `https://tailnet-host.example.ts.net:7447/separation/app/`
+- `https://tailnet-host.example.ts.net:7447/separation/api/health`
+- `https://tailnet-host.example.ts.net:7447/separation/camera/live.stream/`
 
 ## Local build and run
 
@@ -34,7 +34,7 @@ Default bind:
 
 | Variable | Example |
 | --- | --- |
-| `BRAVE_PAWS_PUBLIC_BASE_URL` | `https://quantum.tail080401.ts.net` |
+| `BRAVE_PAWS_PUBLIC_BASE_URL` | `https://tailnet-host.example.ts.net` |
 | `BRAVE_PAWS_DATA_DIR` | `/mnt/q/fermi/brave-paws/data` |
 | `BRAVE_PAWS_AUTH_TOKEN` | `replace-with-shared-secret-if-needed` |
 | `BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL` | `http://127.0.0.1:18888/` |

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "server:build": "npm run build --workspace brave-paws-server",
     "server:lint": "npm run lint --workspace brave-paws-server",
     "server:start": "npm run start --workspace brave-paws-server",
+    "server:create-pairing": "npm run create-pairing --workspace brave-paws-server --",
     "server:test": "npm run test --workspace brave-paws-server",
     "server:clean": "npm run clean --workspace brave-paws-server"
   }


### PR DESCRIPTION
## Summary
- harden the pairing broker for public-safe deployment by requiring configured auth for HTTP pairing creation, returning absolute pairing URLs only from `BRAVE_PAWS_PUBLIC_BASE_URL`, rejecting credential-bearing camera URLs, and serializing pairing-store mutations atomically
- preserve Harvey’s one-click pairing flow and sticky day-to-day browser experience: the app still resolves opaque one-time `pairingToken` URLs, caches the resolved camera link locally, and strips the token from the browser URL
- add targeted regression coverage for concurrent create/consume behavior, malformed tokens, auth gating, and public-base URL behavior, plus fix the pairing CLI usage text for both workspace and root invocations

## Architecture / UX
- Public frontend/app surfaces still stay same-origin and public-safe by default.
- Operators can mint pairings through the local CLI (`npm run server:create-pairing -- --camera-url ...`) or the server API when `BRAVE_PAWS_AUTH_TOKEN` is configured.
- The server can still mint opaque tokens without a public base URL, but it only returns an absolute `pairingUrl` when `BRAVE_PAWS_PUBLIC_BASE_URL` is explicitly configured.

## Safety properties
- pairing broker remains disabled by default
- HTTP pairing creation returns `503` unless `BRAVE_PAWS_AUTH_TOKEN` is configured, so enabling pairing does not silently expose a public write endpoint
- absolute pairing URLs are derived only from `BRAVE_PAWS_PUBLIC_BASE_URL`, never from `Host` / `x-forwarded-proto`
- pairing-store create/consume operations are serialized per file and written atomically via temp-file rename, preventing dropped tokens and double-consume races inside the server process
- malformed pairing-token paths no longer trigger a 500 / stack leak path
- camera URLs with embedded credentials are rejected before they can land in `pairings.json` or client responses

## Verification
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run test:e2e`
- `npm run server:create-pairing --` (verifies corrected usage output)
