### PR TITLE
feat: add backend camera streaming control for v0.2.1

### DIFF
--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSessions } from './store';
 import { Session, Step } from './types';
 import { Dashboard } from './components/Dashboard';
@@ -9,7 +9,9 @@ import { GraphView } from './components/GraphView';
 import { HistoryList } from './components/HistoryList';
 import { SessionView } from './components/SessionView';
 import { InfoView } from './components/InfoView';
+import { CameraStreamingControl } from './components/CameraStreamingControl';
 import { StorageSync } from './components/StorageSync';
+import { useCameraStreamingControl } from './hooks/useCameraStreamingControl';
 import { useStorageSync } from './hooks/useStorageSync';
 import { exportToCSV, parseCSV } from './utils/export';
 import { CAMERA_URL_STORAGE_KEY, getCameraUrlFromSearch } from './utils/cameraUrl';
@@ -42,6 +44,9 @@ export default function App() {
   const [activeSession, setActiveSession] = useState<Session | null>(restoredActiveSessionState?.session ?? null);
   const [activeSessionState, setActiveSessionState] = useState<ActiveSessionState | null>(restoredActiveSessionState);
   const [cameraUrl, setCameraUrl] = useState(() => getCameraUrlFromSearch(window.location.search) || localStorage.getItem(CAMERA_URL_STORAGE_KEY) || '');
+  const cameraStreamingControl = useCameraStreamingControl();
+  const wasTrainingActiveRef = useRef(false);
+  const pendingSessionCameraStateRef = useRef<boolean | null>(restoredActiveSessionState ? true : null);
 
   useEffect(() => {
     installGlobalClientDiagnostics();
@@ -79,6 +84,35 @@ export default function App() {
   }, [replaceSessions]);
 
   const storageSync = useStorageSync(sessions, handleImportSessions);
+
+  useEffect(() => {
+    const isTrainingActive = currentView === 'active' && Boolean(activeSession);
+
+    if (isTrainingActive && !wasTrainingActiveRef.current) {
+      pendingSessionCameraStateRef.current = true;
+    }
+
+    if (!isTrainingActive && wasTrainingActiveRef.current) {
+      pendingSessionCameraStateRef.current = false;
+    }
+
+    wasTrainingActiveRef.current = isTrainingActive;
+  }, [activeSession, currentView]);
+
+  useEffect(() => {
+    const pendingState = pendingSessionCameraStateRef.current;
+    if (pendingState == null || !cameraStreamingControl.capability.canSetEnabled) {
+      return;
+    }
+
+    void cameraStreamingControl.setEnabled(pendingState, { silent: true }).then(() => {
+      if (pendingSessionCameraStateRef.current === pendingState) {
+        pendingSessionCameraStateRef.current = null;
+      }
+    }).catch(() => {
+      // Camera control is best-effort; leave the pending state so a later refresh can retry.
+    });
+  }, [cameraStreamingControl.capability.canSetEnabled, cameraStreamingControl.setEnabled]);
 
   const handleStartNew = () => {
     let initialSteps = DEFAULT_STEPS;
@@ -148,6 +182,7 @@ export default function App() {
             setPreviousView('dashboard');
             setCurrentView('session-view');
           }}
+          cameraStreamingControl={<CameraStreamingControl control={cameraStreamingControl} />}
           storageSync={
             <StorageSync
               provider={storageSync.provider}

--- a/apps/brave-paws-app/src/components/CameraStreamingControl.tsx
+++ b/apps/brave-paws-app/src/components/CameraStreamingControl.tsx
@@ -1,0 +1,71 @@
+import { Camera, LoaderCircle, Power, RefreshCcw } from 'lucide-react';
+
+import type { CameraStreamingControlState } from '../hooks/useCameraStreamingControl';
+
+type Props = {
+  control: CameraStreamingControlState;
+};
+
+export function CameraStreamingControl({ control }: Props) {
+  const { capability, error, isLoading, isUpdating, refresh, toggle } = control;
+  const isSupported = capability.supported && capability.canSetEnabled;
+  const statusLabel = capability.enabled === true ? 'On' : capability.enabled === false ? 'Off' : 'Unknown';
+  const primaryLabel = capability.enabled === true ? 'Turn camera off' : 'Turn camera on';
+
+  return (
+    <section className="bg-white rounded-3xl shadow-sm border border-slate-100 p-5 sm:p-6 space-y-4">
+      <div className="flex items-start gap-3">
+        <div className="rounded-2xl bg-rose-100 p-2.5 text-rose-500">
+          <Camera size={18} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">{capability.label}</p>
+              <h2 className="text-xl font-serif font-bold text-slate-800">Camera streaming</h2>
+            </div>
+            <span className={`rounded-full px-3 py-1 text-xs font-semibold ${capability.enabled === true ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'}`}>
+              {isLoading ? 'Checking…' : statusLabel}
+            </span>
+          </div>
+
+          <p className="mt-2 text-sm text-slate-500">
+            {isSupported
+              ? 'Turn the live camera stream on before training, or switch it off when you only need the history.'
+              : capability.detail || 'This backend does not currently expose camera streaming control.'}
+          </p>
+
+          {error && (
+            <p className="mt-2 text-sm text-amber-700">{error}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          onClick={() => {
+            void toggle();
+          }}
+          disabled={!isSupported || isLoading || isUpdating}
+          className="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
+        >
+          {isUpdating ? <LoaderCircle size={16} className="animate-spin" /> : <Power size={16} />}
+          <span>{isUpdating ? 'Updating…' : primaryLabel}</span>
+        </button>
+
+        <button
+          onClick={() => {
+            void refresh().catch(() => {
+              // The inline error state already reflects the failure.
+            });
+          }}
+          disabled={isLoading || isUpdating}
+          className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-600 transition hover:border-rose-100 hover:bg-rose-50 hover:text-rose-600 disabled:cursor-not-allowed disabled:border-slate-100 disabled:text-slate-300"
+        >
+          <RefreshCcw size={16} />
+          <span>Refresh state</span>
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/brave-paws-app/src/components/Dashboard.tsx
+++ b/apps/brave-paws-app/src/components/Dashboard.tsx
@@ -12,6 +12,7 @@ type Props = {
   onViewHistory: () => void;
   onViewInfo: () => void;
   onViewSession: (session: Session) => void;
+  cameraStreamingControl?: ReactNode;
   storageSync?: ReactNode;
 };
 
@@ -28,6 +29,7 @@ export function Dashboard({
   onViewHistory,
   onViewInfo,
   onViewSession,
+  cameraStreamingControl,
   storageSync,
 }: Props) {
   const abortedSessions = sessions.filter((s) => s.status === 'aborted');
@@ -91,6 +93,8 @@ export function Dashboard({
         </div>
       </div>
 
+      {cameraStreamingControl}
+
       {recentSessions.length > 0 && (
         <button
           onClick={onViewInfo}
@@ -151,7 +155,7 @@ export function Dashboard({
       {storageSync}
 
       <section className="bg-white rounded-3xl shadow-sm border border-slate-100 p-5 sm:p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Brave Paws v0.2</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Brave Paws v0.3</p>
         <div className="mt-2 flex items-start gap-3">
           <div className="rounded-2xl bg-rose-100 p-2.5 text-rose-500">
             <Server size={18} />

--- a/apps/brave-paws-app/src/hooks/useCameraStreamingControl.ts
+++ b/apps/brave-paws-app/src/hooks/useCameraStreamingControl.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  fetchBackendCapabilities,
+  setCameraStreamingEnabled,
+  UNSUPPORTED_CAMERA_STREAMING_CAPABILITY,
+  type CameraStreamingCapability,
+} from '../utils/backendCapabilities';
+
+export type CameraStreamingControlState = {
+  capability: CameraStreamingCapability;
+  isLoading: boolean;
+  isUpdating: boolean;
+  error: string | null;
+  refresh: () => Promise<CameraStreamingCapability>;
+  setEnabled: (enabled: boolean, options?: { silent?: boolean }) => Promise<CameraStreamingCapability>;
+  toggle: () => Promise<CameraStreamingCapability>;
+};
+
+export function useCameraStreamingControl(): CameraStreamingControlState {
+  const [capability, setCapability] = useState<CameraStreamingCapability>(UNSUPPORTED_CAMERA_STREAMING_CAPABILITY);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const capabilityRef = useRef(capability);
+
+  capabilityRef.current = capability;
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = (await fetchBackendCapabilities()).cameraStreaming;
+      setCapability(next);
+      setError(null);
+      return next;
+    } catch (refreshError) {
+      const message = refreshError instanceof Error ? refreshError.message : 'Camera streaming control unavailable';
+      setCapability(UNSUPPORTED_CAMERA_STREAMING_CAPABILITY);
+      setError(message);
+      throw refreshError;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const setEnabled = useCallback(async (enabled: boolean, options?: { silent?: boolean }) => {
+    const current = capabilityRef.current;
+    if (!current.canSetEnabled) {
+      return current;
+    }
+
+    setIsUpdating(true);
+    try {
+      const next = await setCameraStreamingEnabled(enabled);
+      setCapability(next);
+      setError(null);
+      return next;
+    } catch (updateError) {
+      const message = updateError instanceof Error ? updateError.message : 'Could not update camera streaming';
+      if (!options?.silent) {
+        setError(message);
+      }
+      throw updateError;
+    } finally {
+      setIsUpdating(false);
+    }
+  }, []);
+
+  const toggle = useCallback(async () => {
+    const current = capabilityRef.current;
+    return setEnabled(!(current.enabled === true));
+  }, [setEnabled]);
+
+  useEffect(() => {
+    void refresh().catch(() => {
+      // The dashboard can show a graceful unavailable state.
+    });
+  }, [refresh]);
+
+  return {
+    capability,
+    isLoading,
+    isUpdating,
+    error,
+    refresh,
+    setEnabled,
+    toggle,
+  };
+}

--- a/apps/brave-paws-app/src/utils/backendCapabilities.ts
+++ b/apps/brave-paws-app/src/utils/backendCapabilities.ts
@@ -1,0 +1,58 @@
+import { getApiBaseUrl } from '../config';
+
+export type CameraStreamingCapability = {
+  key: 'cameraStreaming';
+  label: string;
+  provider: string;
+  supported: boolean;
+  canSetEnabled: boolean;
+  enabled: boolean | null;
+  detail: string | null;
+};
+
+export type BackendCapabilities = {
+  cameraStreaming: CameraStreamingCapability;
+};
+
+export const UNSUPPORTED_CAMERA_STREAMING_CAPABILITY: CameraStreamingCapability = {
+  key: 'cameraStreaming',
+  label: 'Camera streaming',
+  provider: 'none',
+  supported: false,
+  canSetEnabled: false,
+  enabled: null,
+  detail: 'This backend does not expose camera streaming control.',
+};
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(detail || `Request failed (${response.status})`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function fetchBackendCapabilities(
+  fetchImpl: typeof fetch = fetch,
+  apiBaseUrl = getApiBaseUrl(),
+): Promise<BackendCapabilities> {
+  const response = await fetchImpl(`${apiBaseUrl}capabilities`);
+  return parseJsonResponse<BackendCapabilities>(response);
+}
+
+export async function setCameraStreamingEnabled(
+  enabled: boolean,
+  fetchImpl: typeof fetch = fetch,
+  apiBaseUrl = getApiBaseUrl(),
+): Promise<CameraStreamingCapability> {
+  const response = await fetchImpl(`${apiBaseUrl}capabilities/camera-streaming`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ enabled }),
+  });
+
+  return parseJsonResponse<CameraStreamingCapability>(response);
+}

--- a/apps/brave-paws-app/tests/backend-capabilities.test.ts
+++ b/apps/brave-paws-app/tests/backend-capabilities.test.ts
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fetchBackendCapabilities,
+  setCameraStreamingEnabled,
+  UNSUPPORTED_CAMERA_STREAMING_CAPABILITY,
+} from '../src/utils/backendCapabilities.ts';
+
+test('fetchBackendCapabilities reads the shared capabilities endpoint', async () => {
+  const capabilities = await fetchBackendCapabilities((async (input: string | URL | Request) => {
+    assert.equal(String(input), 'https://brave-paws.example/separation/api/capabilities');
+    return new Response(JSON.stringify({
+      cameraStreaming: {
+        ...UNSUPPORTED_CAMERA_STREAMING_CAPABILITY,
+        supported: true,
+        canSetEnabled: true,
+        enabled: false,
+        provider: 'command',
+        detail: null,
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch, 'https://brave-paws.example/separation/api/');
+
+  assert.equal(capabilities.cameraStreaming.supported, true);
+  assert.equal(capabilities.cameraStreaming.enabled, false);
+  assert.equal(capabilities.cameraStreaming.provider, 'command');
+});
+
+test('setCameraStreamingEnabled posts the desired enabled state to the shared capability endpoint', async () => {
+  const capability = await setCameraStreamingEnabled(true, (async (input: string | URL | Request, init?: RequestInit) => {
+    assert.equal(String(input), 'https://brave-paws.example/separation/api/capabilities/camera-streaming');
+    assert.equal(init?.method, 'POST');
+    assert.equal(init?.headers && (init.headers as Record<string, string>)['content-type'], 'application/json');
+    assert.equal(init?.body, JSON.stringify({ enabled: true }));
+
+    return new Response(JSON.stringify({
+      ...UNSUPPORTED_CAMERA_STREAMING_CAPABILITY,
+      supported: true,
+      canSetEnabled: true,
+      enabled: true,
+      provider: 'command',
+      detail: null,
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch, 'https://brave-paws.example/separation/api/');
+
+  assert.equal(capability.enabled, true);
+  assert.equal(capability.supported, true);
+});

--- a/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
+++ b/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+test('App wires camera streaming control into the dashboard and active session lifecycle', () => {
+  const app = readFileSync(resolve(process.cwd(), 'src/App.tsx'), 'utf8');
+
+  assert.match(app, /useCameraStreamingControl/);
+  assert.match(app, /CameraStreamingControl/);
+  assert.match(app, /currentView === 'active' && Boolean\(activeSession\)/);
+  assert.match(app, /pendingSessionCameraStateRef\.current = true/);
+  assert.match(app, /pendingSessionCameraStateRef\.current = false/);
+  assert.match(app, /setEnabled\(pendingState, \{ silent: true \}\)/);
+});

--- a/apps/brave-paws-app/tests/dashboard-info-button.test.js
+++ b/apps/brave-paws-app/tests/dashboard-info-button.test.js
@@ -3,12 +3,13 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-test('Dashboard includes prominent and subtle info entry points plus the v0.2 Tailnet note', () => {
+test('Dashboard includes info entry points, camera control, and the v0.3 Tailnet note', () => {
   const dashboard = readFileSync(resolve(process.cwd(), 'src/components/Dashboard.tsx'), 'utf8');
 
   assert.match(dashboard, /recentSessions\.length === 0[\s\S]*New to separation anxiety training\?/);
   assert.match(dashboard, /recentSessions\.length > 0[\s\S]*About separation anxiety training/);
-  assert.match(dashboard, /Brave Paws v0\.2/);
+  assert.match(dashboard, /cameraStreamingControl/);
+  assert.match(dashboard, /Brave Paws v0\.3/);
   assert.match(dashboard, /local QUANTUM Tailnet setup/);
   assert.match(dashboard, /Windows streamer companion/);
 });

--- a/apps/brave-paws-landing/index.html
+++ b/apps/brave-paws-landing/index.html
@@ -103,11 +103,11 @@
 
           <article class="panel product-panel tailnet-panel">
             <div class="section-heading compact">
-              <p class="eyebrow">Brave Paws v0.2</p>
+              <p class="eyebrow">Brave Paws v0.3</p>
               <h2>QUANTUM-hosted frontend, backend, and same-origin picam access.</h2>
             </div>
             <p>
-              v0.2 retires the old Brave Paws Streamer helper. QUANTUM now serves the landing page, app, API, and a same-origin camera path in front of picam so the app can stay HTTPS-friendly over Tailnet.
+              v0.3 keeps the local-first Tailnet architecture, adds backend-driven camera streaming control, and keeps the app HTTPS-friendly with a same-origin camera path in front of the live stream.
             </p>
             <div class="architecture-card card">
               <div>

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -1,6 +1,6 @@
 # Brave Paws Server
 
-Brave Paws Server is the local-first QUANTUM backend for Brave Paws v0.2.
+Brave Paws Server is the local-first QUANTUM backend for Brave Paws v0.3.
 
 It serves three things from one localhost process:
 
@@ -26,8 +26,23 @@ It serves three things from one localhost process:
 | `BRAVE_PAWS_PUBLIC_BASE_URL` | unset | Canonical external base URL for docs / logs |
 | `BRAVE_PAWS_DATA_DIR` | `var/brave-paws` in the repo | Session storage directory (live QUANTUM deploy uses `/mnt/q/fermi/brave-paws/data`) |
 | `BRAVE_PAWS_AUTH_TOKEN` | unset | Optional token expected in `x-brave-paws-token` for write requests |
-| `BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL` | `http://127.0.0.1:18888/` | Upstream picam / MediaMTX root that gets proxied under `/separation/camera/` |
+| `BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL` | `http://127.0.0.1:18888/` | Upstream camera / MediaMTX root that gets proxied under `/separation/camera/` |
+| `BRAVE_PAWS_CAMERA_CONTROL_PROVIDER` | `none` | Optional backend capability provider for camera streaming control (`none` or `command`) |
+| `BRAVE_PAWS_CAMERA_CONTROL_LABEL` | `Camera streaming` | Friendly label returned by the capabilities API |
+| `BRAVE_PAWS_CAMERA_STATUS_COMMAND` | unset | Shell command that prints `on` / `off`, `true` / `false`, `1` / `0`, or JSON like `{"enabled":true}` |
+| `BRAVE_PAWS_CAMERA_ENABLE_COMMAND` | unset | Shell command that enables camera streaming when the command provider is active |
+| `BRAVE_PAWS_CAMERA_DISABLE_COMMAND` | unset | Shell command that disables camera streaming when the command provider is active |
 
 ## Storage
 
 Session data is stored as pretty JSON in `sessions.json` and mirrored to `brave_paws_sessions.csv` in the same directory so it stays easy to inspect, back up, and seed from a manual CSV drop.
+
+## Camera streaming capability API
+
+Brave Paws now exposes a backend capability contract for camera streaming control:
+
+- `GET /separation/api/capabilities` → returns the capability map
+- `GET /separation/api/capabilities/camera-streaming` → returns the current camera streaming state
+- `POST /separation/api/capabilities/camera-streaming` with `{ "enabled": true | false }` → requests a state change
+
+The built-in `command` provider is intentionally generic: the server only knows how to run configured shell commands and interpret the returned enabled/disabled state. That keeps the API backend-agnostic so a future provider can control something other than picam without changing the app contract.

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -46,3 +46,5 @@ Brave Paws now exposes a backend capability contract for camera streaming contro
 - `POST /separation/api/capabilities/camera-streaming` with `{ "enabled": true | false }` → requests a state change
 
 The built-in `command` provider is intentionally generic: the server only knows how to run configured shell commands and interpret the returned enabled/disabled state. That keeps the API backend-agnostic so a future provider can control something other than picam without changing the app contract.
+
+For the live QUANTUM deployment, the generic contract is wired to Harvey's existing picam privacy-toggle skill through `deploy/scripts/brave-paws-picam-camera-control.sh`, which adapts the skill's `privacy_mode=...` output into the simple enabled/disabled signal expected by the API.

--- a/apps/brave-paws-server/src/cameraControl.ts
+++ b/apps/brave-paws-server/src/cameraControl.ts
@@ -5,6 +5,8 @@ import type { BravePawsServerConfig } from './config.js';
 
 const execFileAsync = promisify(execFile);
 
+type CameraControlCommandKind = 'status' | 'enable' | 'disable';
+
 export type CameraStreamingCapability = {
   key: 'cameraStreaming';
   label: string;
@@ -22,6 +24,16 @@ export type BackendCapabilities = {
 export interface CameraStreamingController {
   getCapability(): Promise<CameraStreamingCapability>;
   setEnabled(enabled: boolean): Promise<CameraStreamingCapability>;
+}
+
+class CameraControlCommandError extends Error {
+  constructor(
+    message: string,
+    readonly safeDetail: string,
+  ) {
+    super(message);
+    this.name = 'CameraControlCommandError';
+  }
 }
 
 function toShellString(command: string | null | undefined): string | null {
@@ -56,29 +68,72 @@ function parseEnabledValue(raw: string): boolean | null {
   return null;
 }
 
-async function runShellCommand(command: string) {
+function getCommandFailureDetail(kind: CameraControlCommandKind): string {
+  if (kind === 'status') {
+    return 'Camera streaming status unavailable.';
+  }
+
+  return kind === 'enable'
+    ? 'Unable to turn camera streaming on right now.'
+    : 'Unable to turn camera streaming off right now.';
+}
+
+function getSafeCommandErrorDetail(error: unknown, fallback: string): string {
+  if (error instanceof CameraControlCommandError) {
+    return error.safeDetail;
+  }
+
+  return fallback;
+}
+
+async function runShellCommand(command: string, kind: CameraControlCommandKind) {
   try {
-    return await execFileAsync('/bin/sh', ['-lc', command], {
+    return await execFileAsync('/bin/sh', ['-c', command], {
       encoding: 'utf8',
       maxBuffer: 1024 * 1024,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Command failed';
-    throw new Error(message);
+    throw new CameraControlCommandError(message, getCommandFailureDetail(kind));
   }
 }
 
+function buildCapability(options: {
+  label: string;
+  provider: string;
+  supported: boolean;
+  canSetEnabled: boolean;
+  enabled?: boolean | null;
+  detail?: string | null;
+}): CameraStreamingCapability {
+  return {
+    key: 'cameraStreaming',
+    label: options.label,
+    provider: options.provider,
+    supported: options.supported,
+    canSetEnabled: options.canSetEnabled,
+    enabled: options.enabled ?? null,
+    detail: options.detail ?? null,
+  };
+}
+
 class UnsupportedCameraStreamingController implements CameraStreamingController {
+  constructor(
+    private readonly options: {
+      label: string;
+      provider: string;
+      detail: string;
+    },
+  ) {}
+
   async getCapability(): Promise<CameraStreamingCapability> {
-    return {
-      key: 'cameraStreaming',
-      label: 'Camera streaming',
-      provider: 'none',
+    return buildCapability({
+      label: this.options.label,
+      provider: this.options.provider,
       supported: false,
       canSetEnabled: false,
-      enabled: null,
-      detail: 'This backend does not expose camera streaming control.',
-    };
+      detail: this.options.detail,
+    });
   }
 
   async setEnabled(): Promise<CameraStreamingCapability> {
@@ -87,6 +142,8 @@ class UnsupportedCameraStreamingController implements CameraStreamingController 
 }
 
 class CommandCameraStreamingController implements CameraStreamingController {
+  private operationQueue = Promise.resolve();
+
   constructor(
     private readonly options: {
       label: string;
@@ -97,38 +154,68 @@ class CommandCameraStreamingController implements CameraStreamingController {
     },
   ) {}
 
-  async getCapability(): Promise<CameraStreamingCapability> {
+  private async runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.operationQueue.then(operation, operation);
+    this.operationQueue = result.then(() => undefined, () => undefined);
+    return result;
+  }
+
+  private async readCapability(detailOverride: string | null = null): Promise<CameraStreamingCapability> {
     try {
-      const result = await runShellCommand(this.options.statusCommand);
+      const result = await runShellCommand(this.options.statusCommand, 'status');
       const enabled = parseEnabledValue(result.stdout);
 
-      return {
-        key: 'cameraStreaming',
+      return buildCapability({
         label: this.options.label,
         provider: this.options.provider,
         supported: true,
         canSetEnabled: true,
         enabled,
-        detail: enabled == null ? 'Camera streaming status is available but could not be parsed.' : null,
-      };
+        detail: detailOverride ?? (enabled == null ? 'Camera streaming status is available but could not be parsed.' : null),
+      });
     } catch (error) {
-      return {
-        key: 'cameraStreaming',
+      console.error('Camera streaming status command failed', error);
+      return buildCapability({
         label: this.options.label,
         provider: this.options.provider,
         supported: true,
         canSetEnabled: true,
         enabled: null,
-        detail: error instanceof Error ? error.message : 'Camera streaming status unavailable',
-      };
+        detail: detailOverride ?? getSafeCommandErrorDetail(error, 'Camera streaming status unavailable.'),
+      });
     }
   }
 
-  async setEnabled(enabled: boolean): Promise<CameraStreamingCapability> {
-    const command = enabled ? this.options.enableCommand : this.options.disableCommand;
-    await runShellCommand(command);
-    return this.getCapability();
+  async getCapability(): Promise<CameraStreamingCapability> {
+    return this.readCapability();
   }
+
+  async setEnabled(enabled: boolean): Promise<CameraStreamingCapability> {
+    return this.runExclusive(async () => {
+      const kind: CameraControlCommandKind = enabled ? 'enable' : 'disable';
+      const command = enabled ? this.options.enableCommand : this.options.disableCommand;
+
+      try {
+        await runShellCommand(command, kind);
+        return this.readCapability();
+      } catch (error) {
+        console.error(`Camera streaming ${kind} command failed`, error);
+        return this.readCapability(getSafeCommandErrorDetail(error, getCommandFailureDetail(kind)));
+      }
+    });
+  }
+}
+
+function getMissingCommandNames(commands: {
+  statusCommand: string | null;
+  enableCommand: string | null;
+  disableCommand: string | null;
+}) {
+  return [
+    commands.statusCommand ? null : 'status',
+    commands.enableCommand ? null : 'enable',
+    commands.disableCommand ? null : 'disable',
+  ].filter((value): value is 'status' | 'enable' | 'disable' => value != null);
 }
 
 export function createCameraStreamingController(config: BravePawsServerConfig): CameraStreamingController {
@@ -136,22 +223,35 @@ export function createCameraStreamingController(config: BravePawsServerConfig): 
   const enableCommand = toShellString(config.cameraControlEnableCommand);
   const disableCommand = toShellString(config.cameraControlDisableCommand);
 
-  if (
-    config.cameraControlProvider === 'command'
-    && statusCommand
-    && enableCommand
-    && disableCommand
-  ) {
-    return new CommandCameraStreamingController({
-      label: config.cameraControlLabel,
-      provider: config.cameraControlProvider,
+  if (config.cameraControlProvider === 'command') {
+    const missingCommands = getMissingCommandNames({
       statusCommand,
       enableCommand,
       disableCommand,
     });
+
+    if (!missingCommands.length) {
+      return new CommandCameraStreamingController({
+        label: config.cameraControlLabel,
+        provider: config.cameraControlProvider,
+        statusCommand: statusCommand!,
+        enableCommand: enableCommand!,
+        disableCommand: disableCommand!,
+      });
+    }
+
+    return new UnsupportedCameraStreamingController({
+      label: config.cameraControlLabel,
+      provider: config.cameraControlProvider,
+      detail: `Camera streaming command provider is misconfigured: missing ${missingCommands.join(', ')} command${missingCommands.length === 1 ? '' : 's'}.`,
+    });
   }
 
-  return new UnsupportedCameraStreamingController();
+  return new UnsupportedCameraStreamingController({
+    label: config.cameraControlLabel,
+    provider: 'none',
+    detail: 'This backend does not expose camera streaming control.',
+  });
 }
 
 export async function getBackendCapabilities(controller: CameraStreamingController): Promise<BackendCapabilities> {

--- a/apps/brave-paws-server/src/cameraControl.ts
+++ b/apps/brave-paws-server/src/cameraControl.ts
@@ -1,0 +1,161 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { BravePawsServerConfig } from './config.js';
+
+const execFileAsync = promisify(execFile);
+
+export type CameraStreamingCapability = {
+  key: 'cameraStreaming';
+  label: string;
+  provider: string;
+  supported: boolean;
+  canSetEnabled: boolean;
+  enabled: boolean | null;
+  detail: string | null;
+};
+
+export type BackendCapabilities = {
+  cameraStreaming: CameraStreamingCapability;
+};
+
+export interface CameraStreamingController {
+  getCapability(): Promise<CameraStreamingCapability>;
+  setEnabled(enabled: boolean): Promise<CameraStreamingCapability>;
+}
+
+function toShellString(command: string | null | undefined): string | null {
+  const trimmed = command?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parseEnabledValue(raw: string): boolean | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as { enabled?: unknown };
+    if (typeof parsed?.enabled === 'boolean') {
+      return parsed.enabled;
+    }
+  } catch {
+    // Fall through to common string values.
+  }
+
+  const normalized = trimmed.toLowerCase();
+  if (['1', 'true', 'enabled', 'on', 'active', 'running', 'yes'].includes(normalized)) {
+    return true;
+  }
+
+  if (['0', 'false', 'disabled', 'off', 'inactive', 'stopped', 'no'].includes(normalized)) {
+    return false;
+  }
+
+  return null;
+}
+
+async function runShellCommand(command: string) {
+  try {
+    return await execFileAsync('/bin/sh', ['-lc', command], {
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Command failed';
+    throw new Error(message);
+  }
+}
+
+class UnsupportedCameraStreamingController implements CameraStreamingController {
+  async getCapability(): Promise<CameraStreamingCapability> {
+    return {
+      key: 'cameraStreaming',
+      label: 'Camera streaming',
+      provider: 'none',
+      supported: false,
+      canSetEnabled: false,
+      enabled: null,
+      detail: 'This backend does not expose camera streaming control.',
+    };
+  }
+
+  async setEnabled(): Promise<CameraStreamingCapability> {
+    return this.getCapability();
+  }
+}
+
+class CommandCameraStreamingController implements CameraStreamingController {
+  constructor(
+    private readonly options: {
+      label: string;
+      provider: string;
+      statusCommand: string;
+      enableCommand: string;
+      disableCommand: string;
+    },
+  ) {}
+
+  async getCapability(): Promise<CameraStreamingCapability> {
+    try {
+      const result = await runShellCommand(this.options.statusCommand);
+      const enabled = parseEnabledValue(result.stdout);
+
+      return {
+        key: 'cameraStreaming',
+        label: this.options.label,
+        provider: this.options.provider,
+        supported: true,
+        canSetEnabled: true,
+        enabled,
+        detail: enabled == null ? 'Camera streaming status is available but could not be parsed.' : null,
+      };
+    } catch (error) {
+      return {
+        key: 'cameraStreaming',
+        label: this.options.label,
+        provider: this.options.provider,
+        supported: true,
+        canSetEnabled: true,
+        enabled: null,
+        detail: error instanceof Error ? error.message : 'Camera streaming status unavailable',
+      };
+    }
+  }
+
+  async setEnabled(enabled: boolean): Promise<CameraStreamingCapability> {
+    const command = enabled ? this.options.enableCommand : this.options.disableCommand;
+    await runShellCommand(command);
+    return this.getCapability();
+  }
+}
+
+export function createCameraStreamingController(config: BravePawsServerConfig): CameraStreamingController {
+  const statusCommand = toShellString(config.cameraControlStatusCommand);
+  const enableCommand = toShellString(config.cameraControlEnableCommand);
+  const disableCommand = toShellString(config.cameraControlDisableCommand);
+
+  if (
+    config.cameraControlProvider === 'command'
+    && statusCommand
+    && enableCommand
+    && disableCommand
+  ) {
+    return new CommandCameraStreamingController({
+      label: config.cameraControlLabel,
+      provider: config.cameraControlProvider,
+      statusCommand,
+      enableCommand,
+      disableCommand,
+    });
+  }
+
+  return new UnsupportedCameraStreamingController();
+}
+
+export async function getBackendCapabilities(controller: CameraStreamingController): Promise<BackendCapabilities> {
+  return {
+    cameraStreaming: await controller.getCapability(),
+  };
+}

--- a/apps/brave-paws-server/src/config.ts
+++ b/apps/brave-paws-server/src/config.ts
@@ -44,6 +44,11 @@ export type BravePawsServerConfig = {
   dataDir: string;
   dataFilePath: string;
   cameraUpstreamBaseUrl: string;
+  cameraControlProvider: 'none' | 'command';
+  cameraControlLabel: string;
+  cameraControlStatusCommand: string | null;
+  cameraControlEnableCommand: string | null;
+  cameraControlDisableCommand: string | null;
   authToken: string | null;
 };
 
@@ -69,6 +74,11 @@ export function resolveConfig(env = process.env): BravePawsServerConfig {
     dataDir,
     dataFilePath: path.join(dataDir, 'sessions.json'),
     cameraUpstreamBaseUrl: (env.BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL || 'http://127.0.0.1:18888/').replace(/\/?$/, '/'),
+    cameraControlProvider: env.BRAVE_PAWS_CAMERA_CONTROL_PROVIDER === 'command' ? 'command' : 'none',
+    cameraControlLabel: env.BRAVE_PAWS_CAMERA_CONTROL_LABEL || 'Camera streaming',
+    cameraControlStatusCommand: env.BRAVE_PAWS_CAMERA_STATUS_COMMAND?.trim() || null,
+    cameraControlEnableCommand: env.BRAVE_PAWS_CAMERA_ENABLE_COMMAND?.trim() || null,
+    cameraControlDisableCommand: env.BRAVE_PAWS_CAMERA_DISABLE_COMMAND?.trim() || null,
     authToken: env.BRAVE_PAWS_AUTH_TOKEN || null,
   };
 }

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -5,6 +5,11 @@ import path from 'node:path';
 
 import { resolveConfig, type BravePawsServerConfig } from './config.js';
 import {
+  createCameraStreamingController,
+  getBackendCapabilities,
+  type CameraStreamingController,
+} from './cameraControl.js';
+import {
   appendClientDiagnostic,
   readSessionStore,
   upsertSession,
@@ -388,7 +393,7 @@ async function proxyCameraRequest(
       method: request.method,
       headers: {
         accept: request.headers.accept || '*/*',
-        'user-agent': request.headers['user-agent'] || 'BravePawsServer/0.2',
+        'user-agent': request.headers['user-agent'] || 'BravePawsServer/0.3',
       },
     });
 
@@ -422,7 +427,11 @@ async function handleApiRequest(
   response: ServerResponse,
   pathname: string,
   config: BravePawsServerConfig,
+  cameraStreamingController: CameraStreamingController,
 ) {
+  const capabilitiesPath = `${config.apiBasePath}capabilities`;
+  const cameraStreamingCapabilityPath = `${capabilitiesPath}/camera-streaming`;
+
   if (pathname === config.healthPath) {
     const store = await readSessionStore(config.dataFilePath);
     sendJson(response, 200, {
@@ -432,6 +441,7 @@ async function handleApiRequest(
       apiBasePath: config.apiBasePath,
       cameraBasePath: config.cameraBasePath,
       clientDiagnosticsPath: config.clientDiagnosticsPath,
+      capabilitiesPath,
       sessionCount: store.sessions.length,
       updatedAt: store.updatedAt,
     });
@@ -442,6 +452,35 @@ async function handleApiRequest(
   const syncPullPath = `${config.apiBasePath}sync/pull`;
   const syncPushPath = `${config.apiBasePath}sync/push`;
   const clientDiagnosticsPath = config.clientDiagnosticsPath;
+
+  if (request.method === 'GET' && pathname === capabilitiesPath) {
+    const capabilities = await getBackendCapabilities(cameraStreamingController);
+    sendJson(response, 200, capabilities);
+    return;
+  }
+
+  if (pathname === cameraStreamingCapabilityPath) {
+    if (request.method === 'GET') {
+      sendJson(response, 200, await cameraStreamingController.getCapability());
+      return;
+    }
+
+    if (request.method === 'POST') {
+      if (!isWriteAuthorized(request, config)) {
+        sendJson(response, 401, { error: 'Unauthorized' });
+        return;
+      }
+
+      const payload = await readJsonBody<{ enabled?: boolean }>(request);
+      if (typeof payload.enabled !== 'boolean') {
+        sendJson(response, 400, { error: 'enabled boolean is required' });
+        return;
+      }
+
+      sendJson(response, 200, await cameraStreamingController.setEnabled(payload.enabled));
+      return;
+    }
+  }
 
   if (request.method === 'GET' && pathname === sessionsCollectionPath) {
     const store = await readSessionStore(config.dataFilePath);
@@ -536,6 +575,8 @@ async function handleApiRequest(
 }
 
 export function createBravePawsServer(config = resolveConfig()) {
+  const cameraStreamingController = createCameraStreamingController(config);
+
   const server = http.createServer(async (request, response) => {
     try {
       if (!request.url) {
@@ -578,7 +619,7 @@ export function createBravePawsServer(config = resolveConfig()) {
       }
 
       if (pathname.startsWith(config.apiBasePath)) {
-        await handleApiRequest(request, response, pathname, config);
+        await handleApiRequest(request, response, pathname, config, cameraStreamingController);
         return;
       }
 
@@ -630,7 +671,11 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     console.log(`Brave Paws server listening on http://${config.host}:${config.port}`);
     console.log(`Landing page: ${publicHint}`);
     console.log(`API health: http://${config.host}:${config.port}${config.healthPath}`);
+    console.log(`Capabilities: http://${config.host}:${config.port}${config.apiBasePath}capabilities`);
     console.log(`Camera proxy: http://${config.host}:${config.port}${config.cameraBasePath}live.stream/`);
     console.log(`Session store: ${config.dataFilePath}`);
+    if (config.cameraControlProvider === 'command') {
+      console.log(`Camera streaming control: ${config.cameraControlLabel}`);
+    }
   });
 }

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -7,6 +7,7 @@ import { resolveConfig, type BravePawsServerConfig } from './config.js';
 import {
   createCameraStreamingController,
   getBackendCapabilities,
+  type CameraStreamingCapability,
   type CameraStreamingController,
 } from './cameraControl.js';
 import {
@@ -403,7 +404,7 @@ async function proxyCameraRequest(
       method: request.method,
       headers: {
         accept: request.headers.accept || '*/*',
-        'user-agent': request.headers['user-agent'] || 'BravePawsServer/0.3',
+        'user-agent': request.headers['user-agent'] || 'BravePawsServer/0.2.1',
       },
     });
 
@@ -755,6 +756,7 @@ export function createBravePawsServer(config = resolveConfig()) {
 if (import.meta.url === `file://${process.argv[1]}`) {
   const config = resolveConfig();
   const server = createBravePawsServer(config);
+  const startupCameraStreamingController = createCameraStreamingController(config);
 
   server.listen(config.port, config.host, () => {
     const publicHint = config.publicBaseUrl
@@ -767,9 +769,21 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     console.log(`Capabilities: http://${config.host}:${config.port}${config.apiBasePath}capabilities`);
     console.log(`Camera proxy: http://${config.host}:${config.port}${config.cameraBasePath}live.stream/`);
     console.log(`Session store: ${config.dataFilePath}`);
-    if (config.cameraControlProvider === 'command') {
-      console.log(`Camera streaming control: ${config.cameraControlLabel}`);
-    }
+    void startupCameraStreamingController.getCapability().then((capability: CameraStreamingCapability) => {
+      if (capability.provider === 'command') {
+        if (capability.supported && capability.canSetEnabled) {
+          console.log(`Camera streaming control: ${capability.label}`);
+          if (capability.detail) {
+            console.warn(capability.detail);
+          }
+          return;
+        }
+
+        console.warn(capability.detail || 'Camera streaming command provider is configured but unavailable.');
+      }
+    }).catch((error: unknown) => {
+      console.warn('Camera streaming control startup check failed.', error);
+    });
     if (config.pairingEnabled) {
       console.log(`Pairing broker: http://${config.host}:${config.port}${config.apiBasePath}pairings`);
       if (!config.authToken) {

--- a/apps/brave-paws-server/tests/cameraControl.test.ts
+++ b/apps/brave-paws-server/tests/cameraControl.test.ts
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createCameraStreamingController } from '../src/cameraControl.ts';
+import type { BravePawsServerConfig } from '../src/config.ts';
+
+function makeConfig(overrides: Partial<BravePawsServerConfig> = {}): BravePawsServerConfig {
+  return {
+    host: '127.0.0.1',
+    port: 4310,
+    publicBaseUrl: null,
+    landingBasePath: '/separation/',
+    appBasePath: '/separation/app/',
+    apiBasePath: '/separation/api/',
+    cameraBasePath: '/separation/camera/',
+    healthPath: '/separation/api/health',
+    clientDiagnosticsPath: '/separation/api/client-diagnostics',
+    landingDistDir: '/tmp/landing',
+    appDistDir: '/tmp/app',
+    dataDir: '/tmp/data',
+    dataFilePath: '/tmp/data/sessions.json',
+    pairingStoreFilePath: '/tmp/data/pairings.json',
+    pairingEnabled: false,
+    cameraUpstreamBaseUrl: 'http://127.0.0.1:18888/',
+    cameraControlProvider: 'none',
+    cameraControlLabel: 'Camera streaming',
+    cameraControlStatusCommand: null,
+    cameraControlEnableCommand: null,
+    cameraControlDisableCommand: null,
+    authToken: null,
+    ...overrides,
+  };
+}
+
+test('createCameraStreamingController reports command-provider misconfiguration explicitly', async () => {
+  const controller = createCameraStreamingController(makeConfig({
+    cameraControlProvider: 'command',
+    cameraControlEnableCommand: 'printf on\\n',
+  }));
+
+  const capability = await controller.getCapability();
+  assert.equal(capability.provider, 'command');
+  assert.equal(capability.supported, false);
+  assert.equal(capability.canSetEnabled, false);
+  assert.match(capability.detail || '', /missing status, disable commands/i);
+});
+
+test('setEnabled serializes command execution to avoid overlapping transitions', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-camera-control-queue-'));
+  const stateFilePath = path.join(tempDir, 'camera-state.txt');
+  const logFilePath = path.join(tempDir, 'camera-ops.log');
+  await fs.writeFile(stateFilePath, 'off\n');
+  await fs.writeFile(logFilePath, '');
+
+  const shellQuote = (value: string) => JSON.stringify(value);
+  const controller = createCameraStreamingController(makeConfig({
+    cameraControlProvider: 'command',
+    cameraControlStatusCommand: `cat ${shellQuote(stateFilePath)}`,
+    cameraControlEnableCommand: [
+      `printf 'enable-start\\n' >> ${shellQuote(logFilePath)}`,
+      'sleep 0.2',
+      `printf 'on\\n' > ${shellQuote(stateFilePath)}`,
+      `printf 'enable-end\\n' >> ${shellQuote(logFilePath)}`,
+    ].join('; '),
+    cameraControlDisableCommand: [
+      `printf 'disable-start\\n' >> ${shellQuote(logFilePath)}`,
+      'sleep 0.2',
+      `printf 'off\\n' > ${shellQuote(stateFilePath)}`,
+      `printf 'disable-end\\n' >> ${shellQuote(logFilePath)}`,
+    ].join('; '),
+  }));
+
+  try {
+    await Promise.all([
+      controller.setEnabled(true),
+      controller.setEnabled(false),
+    ]);
+
+    const operations = (await fs.readFile(logFilePath, 'utf8'))
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+
+    assert.deepEqual(operations, [
+      'enable-start',
+      'enable-end',
+      'disable-start',
+      'disable-end',
+    ]);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -172,6 +172,64 @@ test('camera streaming capability can be toggled through the command provider', 
   }
 });
 
+test('camera command misconfiguration stays visible through the capability payload', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await fetch(`${baseUrl}/separation/api/capabilities/camera-streaming`);
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      provider: string;
+      supported: boolean;
+      canSetEnabled: boolean;
+      detail: string | null;
+    };
+
+    assert.equal(body.provider, 'command');
+    assert.equal(body.supported, false);
+    assert.equal(body.canSetEnabled, false);
+    assert.match(body.detail || '', /missing status, disable commands/i);
+  }, {
+    cameraControlProvider: 'command',
+    cameraControlEnableCommand: 'printf on\\n',
+  });
+});
+
+test('camera command failures return a structured capability payload without leaking command details', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-camera-control-failure-'));
+  const stateFilePath = path.join(tempDir, 'camera-state.txt');
+  await fs.writeFile(stateFilePath, 'off\n');
+
+  try {
+    await withFixtureServer(async ({ baseUrl }) => {
+      const response = await fetch(`${baseUrl}/separation/api/capabilities/camera-streaming`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      });
+
+      assert.equal(response.status, 200);
+      const body = await response.json() as {
+        provider: string;
+        supported: boolean;
+        enabled: boolean | null;
+        detail: string | null;
+      };
+
+      assert.equal(body.provider, 'command');
+      assert.equal(body.supported, true);
+      assert.equal(body.enabled, false);
+      assert.equal(body.detail, 'Unable to turn camera streaming on right now.');
+      assert.doesNotMatch(JSON.stringify(body), /secret-path|camera-state\.txt|totally-broken-command/);
+    }, {
+      cameraControlProvider: 'command',
+      cameraControlStatusCommand: `cat ${JSON.stringify(stateFilePath)}`,
+      cameraControlEnableCommand: 'printf "secret-path\n" >&2; totally-broken-command',
+      cameraControlDisableCommand: `printf 'off\n' > ${JSON.stringify(stateFilePath)}`,
+    });
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('sync push and pull round-trip sessions to disk', async () => {
   await withFixtureServer(async ({ baseUrl, config }) => {
     const sessions = [{ 

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -22,7 +22,10 @@ async function close(server: http.Server) {
   await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
 }
 
-async function withFixtureServer(run: (context: { baseUrl: string; config: BravePawsServerConfig }) => Promise<void>) {
+async function withFixtureServer(
+  run: (context: { baseUrl: string; config: BravePawsServerConfig }) => Promise<void>,
+  configOverrides: Partial<BravePawsServerConfig> = {},
+) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-server-'));
   const landingDir = path.join(tempDir, 'landing');
   const appDir = path.join(tempDir, 'app');
@@ -55,7 +58,13 @@ async function withFixtureServer(run: (context: { baseUrl: string; config: Brave
     dataDir,
     dataFilePath: path.join(dataDir, 'sessions.json'),
     cameraUpstreamBaseUrl: `${upstreamBaseUrl}/`,
+    cameraControlProvider: 'none',
+    cameraControlLabel: 'Camera streaming',
+    cameraControlStatusCommand: null,
+    cameraControlEnableCommand: null,
+    cameraControlDisableCommand: null,
     authToken: null,
+    ...configOverrides,
   };
 
   const server = createBravePawsServer(config);
@@ -83,9 +92,59 @@ test('health endpoint reports session metadata without leaking server file paths
   });
 });
 
+test('camera capabilities report unsupported control by default', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await fetch(`${baseUrl}/separation/api/capabilities`);
+    assert.equal(response.status, 200);
+    const body = await response.json() as { cameraStreaming: { supported: boolean; canSetEnabled: boolean; enabled: boolean | null } };
+    assert.equal(body.cameraStreaming.supported, false);
+    assert.equal(body.cameraStreaming.canSetEnabled, false);
+    assert.equal(body.cameraStreaming.enabled, null);
+  });
+});
+
+test('camera streaming capability can be toggled through the command provider', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-camera-control-'));
+  const stateFilePath = path.join(tempDir, 'camera-state.txt');
+  await fs.writeFile(stateFilePath, 'off\n');
+
+  try {
+    await withFixtureServer(async ({ baseUrl }) => {
+      const before = await fetch(`${baseUrl}/separation/api/capabilities/camera-streaming`);
+      assert.equal(before.status, 200);
+      assert.equal((await before.json() as { enabled: boolean | null }).enabled, false);
+
+      const enableResponse = await fetch(`${baseUrl}/separation/api/capabilities/camera-streaming`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      });
+      assert.equal(enableResponse.status, 200);
+      assert.equal((await enableResponse.json() as { enabled: boolean | null }).enabled, true);
+      assert.equal((await fs.readFile(stateFilePath, 'utf8')).trim(), 'on');
+
+      const disableResponse = await fetch(`${baseUrl}/separation/api/capabilities/camera-streaming`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      });
+      assert.equal(disableResponse.status, 200);
+      assert.equal((await disableResponse.json() as { enabled: boolean | null }).enabled, false);
+      assert.equal((await fs.readFile(stateFilePath, 'utf8')).trim(), 'off');
+    }, {
+      cameraControlProvider: 'command',
+      cameraControlStatusCommand: `cat ${JSON.stringify(stateFilePath)}`,
+      cameraControlEnableCommand: `printf 'on\n' > ${JSON.stringify(stateFilePath)}`,
+      cameraControlDisableCommand: `printf 'off\n' > ${JSON.stringify(stateFilePath)}`,
+    });
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('sync push and pull round-trip sessions to disk', async () => {
   await withFixtureServer(async ({ baseUrl, config }) => {
-    const sessions = [{
+    const sessions = [{ 
       id: 'session-1',
       date: '2026-05-03T11:00:00.000Z',
       steps: [{ id: 'step-1', durationSeconds: 30, status: 'completed' }],
@@ -238,6 +297,42 @@ test('client diagnostics endpoint appends sanitized frontend events to disk', as
   });
 });
 
+test('camera streaming control requires auth when a token is configured', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-camera-auth-'));
+  const stateFilePath = path.join(tempDir, 'camera-state.txt');
+  await fs.writeFile(stateFilePath, 'off\n');
+
+  try {
+    await withFixtureServer(async ({ baseUrl }) => {
+      const unauthorized = await fetch(`${baseUrl}/separation/api/capabilities/camera-streaming`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      });
+      assert.equal(unauthorized.status, 401);
+
+      const authorized = await fetch(`${baseUrl}/separation/api/capabilities/camera-streaming`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-brave-paws-token': 'secret-token',
+        },
+        body: JSON.stringify({ enabled: true }),
+      });
+      assert.equal(authorized.status, 200);
+      assert.equal((await authorized.json() as { enabled: boolean | null }).enabled, true);
+    }, {
+      authToken: 'secret-token',
+      cameraControlProvider: 'command',
+      cameraControlStatusCommand: `cat ${JSON.stringify(stateFilePath)}`,
+      cameraControlEnableCommand: `printf 'on\n' > ${JSON.stringify(stateFilePath)}`,
+      cameraControlDisableCommand: `printf 'off\n' > ${JSON.stringify(stateFilePath)}`,
+    });
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('client diagnostics endpoint requires auth when a token is configured', async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-server-auth-'));
   const landingDir = path.join(tempDir, 'landing');
@@ -270,6 +365,11 @@ test('client diagnostics endpoint requires auth when a token is configured', asy
     dataDir,
     dataFilePath: path.join(dataDir, 'sessions.json'),
     cameraUpstreamBaseUrl: `${upstreamBaseUrl}/`,
+    cameraControlProvider: 'none',
+    cameraControlLabel: 'Camera streaming',
+    cameraControlStatusCommand: null,
+    cameraControlEnableCommand: null,
+    cameraControlDisableCommand: null,
     authToken: 'secret-token',
   };
 

--- a/deploy/scripts/brave-paws-picam-camera-control.sh
+++ b/deploy/scripts/brave-paws-picam-camera-control.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PICAM_PRIVACY_SCRIPT="${BRAVE_PAWS_PICAM_PRIVACY_SCRIPT:-$HOME/.openclaw/workspace/skills/picam-privacy-toggle/scripts/picam-privacy.sh}"
+
+usage() {
+  cat <<'EOF'
+Usage: brave-paws-picam-camera-control.sh <status|enable|disable>
+
+status   Print `on` when picam streaming is enabled, `off` when privacy mode is active.
+enable   Re-enable picam streaming via the shared privacy-toggle skill.
+disable  Disable picam streaming via the shared privacy-toggle skill.
+
+Environment:
+  BRAVE_PAWS_PICAM_PRIVACY_SCRIPT   Override the underlying picam privacy skill path.
+  PICAM_HOST_ALIAS                  Optional host alias forwarded to the skill script.
+EOF
+}
+
+require_skill_script() {
+  if [[ ! -x "$PICAM_PRIVACY_SCRIPT" ]]; then
+    echo "picam privacy script is missing or not executable: $PICAM_PRIVACY_SCRIPT" >&2
+    exit 1
+  fi
+}
+
+run_skill() {
+  require_skill_script
+  "$PICAM_PRIVACY_SCRIPT" "$@"
+}
+
+status_cmd() {
+  local output privacy_mode
+  output="$(run_skill status)"
+  privacy_mode="$(awk -F= '/^privacy_mode=/{print $2; exit}' <<<"$output")"
+
+  case "$privacy_mode" in
+    off) echo on ;;
+    on) echo off ;;
+    *)
+      echo "Unable to parse picam privacy status" >&2
+      echo "$output" >&2
+      exit 1
+      ;;
+  esac
+}
+
+main() {
+  local command="${1:-}"
+  case "$command" in
+    status) status_cmd ;;
+    enable) run_skill enable ;;
+    disable) run_skill disable ;;
+    -h|--help|help|'') usage ;;
+    *)
+      echo "Unknown command: $command" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/deploy/systemd/brave-paws.service
+++ b/deploy/systemd/brave-paws.service
@@ -13,6 +13,11 @@ Environment=BRAVE_PAWS_PORT=4310
 Environment=BRAVE_PAWS_PUBLIC_BASE_URL=https://quantum.tail080401.ts.net:7447
 Environment="BRAVE_PAWS_DATA_DIR=/mnt/q/fermi/brave-paws/data"
 Environment=BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL=http://127.0.0.1:18888/
+Environment=BRAVE_PAWS_CAMERA_CONTROL_PROVIDER=command
+Environment="BRAVE_PAWS_CAMERA_CONTROL_LABEL=Picam streaming"
+Environment="BRAVE_PAWS_CAMERA_STATUS_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh status"
+Environment="BRAVE_PAWS_CAMERA_ENABLE_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh enable"
+Environment="BRAVE_PAWS_CAMERA_DISABLE_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh disable"
 ExecStart=/usr/bin/env npm --prefix /mnt/q/repos/separation-tracker run server:start
 Restart=on-failure
 RestartSec=3

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -38,6 +38,10 @@ Default bind:
 | `BRAVE_PAWS_DATA_DIR` | `/mnt/q/fermi/brave-paws/data` |
 | `BRAVE_PAWS_AUTH_TOKEN` | `replace-with-shared-secret-if-needed` |
 | `BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL` | `http://127.0.0.1:18888/` |
+| `BRAVE_PAWS_CAMERA_CONTROL_PROVIDER` | `command` |
+| `BRAVE_PAWS_CAMERA_STATUS_COMMAND` | `/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh status` |
+| `BRAVE_PAWS_CAMERA_ENABLE_COMMAND` | `/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh enable` |
+| `BRAVE_PAWS_CAMERA_DISABLE_COMMAND` | `/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh disable` |
 
 ## Session storage
 
@@ -69,4 +73,5 @@ If Harvey drops a fresher `brave_paws_sessions.csv` into the data folder, the se
 ## Notes
 
 - The camera path is a same-origin proxy in front of picam / MediaMTX, and directory-style preview URLs such as `/separation/camera/live.stream` are redirected to the working trailing-slash preview page automatically.
+- QUANTUM's deployment now wires the generic camera-streaming capability API to the existing OpenClaw picam privacy-toggle skill through `deploy/scripts/brave-paws-picam-camera-control.sh`, so the Brave Paws dashboard toggle and session lifecycle automation drive the same underlying picam enable/disable behavior as the assistant skill.
 - Local browser persistence still exists in the app; QUANTUM hydrates on open and automatically pushes changes back to the inspectable QUANTUM data folder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "separation-tracker",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "separation-tracker",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "workspaces": [
         "apps/brave-paws-landing",
         "apps/brave-paws-app",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "separation-tracker",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "workspaces": [
     "apps/brave-paws-landing",


### PR DESCRIPTION
## Summary
- add a backend camera streaming capability contract with a generic command-based provider and API endpoints
- add a dashboard camera streaming control card plus app-side capability client and hook
- automatically enable camera streaming when a training session starts and disable it when it ends

## Testing
- npm run app:test
- npm run server:test
- npm run app:lint
- npm run server:lint
- npm run build