### PR TITLE
feat: add Brave Paws session recording

### DIFF
--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -181,11 +181,9 @@ export default function App() {
   };
 
   const handleCancelSession = () => {
-    if (window.confirm('Are you sure you want to cancel this session? Progress will not be saved.')) {
-      setActiveSession(null);
-      setActiveSessionState(null);
-      setCurrentView('dashboard');
-    }
+    setActiveSession(null);
+    setActiveSessionState(null);
+    setCurrentView('dashboard');
   };
 
   return (

--- a/apps/brave-paws-app/src/components/ActiveSession.tsx
+++ b/apps/brave-paws-app/src/components/ActiveSession.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Session, StepStatus } from '../types';
+import { Session, SessionRecording, StepStatus } from '../types';
 import { Play, Pause, CheckCircle2, Circle, Flag, X, Heart, VideoOff, RotateCcw, Minimize2, Maximize2 } from 'lucide-react';
 import { formatTime, formatDuration } from '../utils/format';
 import { buildCameraStreamUrl, isCameraUrlValid } from '../utils/cameraUrl';
@@ -7,6 +7,12 @@ import { CameraLinkInput } from './CameraLinkInput';
 import { TimerClock, getElapsedSeconds, getRemainingSeconds, pauseTimer, startTimer } from '../utils/timer';
 import { ActiveSessionState } from '../utils/activeSessionStorage';
 import { reportClientDiagnostic } from '../utils/clientDiagnostics';
+import {
+  startSessionRecording,
+  stopSessionRecording,
+  UNSUPPORTED_SESSION_RECORDING_CAPABILITY,
+  type SessionRecordingCapability,
+} from '../utils/backendCapabilities';
 
 const PREVIEW_LOAD_TIMEOUT_MS = 12000;
 
@@ -60,6 +66,10 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
   const [previewStatusMessage, setPreviewStatusMessage] = useState('Paste a stream URL, open a one-time pairing link, or use the suggested picam link to start the live preview.');
   const [isPreviewConnected, setIsPreviewConnected] = useState(() => isCameraUrlValid(cameraUrl));
   const [isPreviewMinimized, setIsPreviewMinimized] = useState(false);
+  const [recordingCapability, setRecordingCapability] = useState<SessionRecordingCapability>(UNSUPPORTED_SESSION_RECORDING_CAPABILITY);
+  const [isRecordingLoading, setIsRecordingLoading] = useState(true);
+  const [isRecordingUpdating, setIsRecordingUpdating] = useState(false);
+  const [recordingError, setRecordingError] = useState<string | null>(null);
   const lastLoggedPreviewStatusRef = useRef<string | null>(null);
   const sessionRef = useRef(session);
   const sessionClockRef = useRef(sessionClock);
@@ -128,6 +138,41 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       }
   }, [finalizeStep]);
 
+  const applyRecordingCapability = useCallback((capability: SessionRecordingCapability) => {
+    setRecordingCapability(capability);
+    setRecordingError(capability.detail ?? null);
+
+    if (!capability.recording) {
+      return null;
+    }
+
+    const nextRecording = capability.recording;
+    setSession((prev) => {
+      const updatedSession = {
+        ...prev,
+        recording: nextRecording,
+      };
+      sessionRef.current = updatedSession;
+      return updatedSession;
+    });
+
+    return nextRecording;
+  }, []);
+
+  const buildFailedRecording = useCallback((detail: string): SessionRecording => ({
+    status: 'failed',
+    sessionId: sessionRef.current.id,
+    provider: recordingCapability.provider || 'unknown',
+    startedAt: sessionRef.current.recording?.startedAt ?? null,
+    stoppedAt: new Date().toISOString(),
+    hasAudio: false,
+    relativeFilePath: sessionRef.current.recording?.relativeFilePath ?? null,
+    downloadPath: sessionRef.current.recording?.downloadPath ?? null,
+    durationSeconds: sessionRef.current.recording?.durationSeconds ?? null,
+    sizeBytes: sessionRef.current.recording?.sizeBytes ?? null,
+    detail,
+  }), [recordingCapability.provider]);
+
   // Background Stopwatch
   useEffect(() => {
     syncSessionElapsed();
@@ -185,6 +230,50 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
   }, [syncSessionElapsed, syncStepRemaining]);
 
   useEffect(() => {
+    let isCancelled = false;
+
+    const ensureRecording = async () => {
+      setIsRecordingLoading(true);
+      try {
+        const capability = await startSessionRecording({
+          sessionId: initialSession.id,
+          sessionDate: initialSession.date,
+          sessionStatus: restoredState?.session.status ?? initialSession.status,
+        });
+        if (!isCancelled) {
+          applyRecordingCapability(capability);
+        }
+      } catch (recordingStartError) {
+        if (!isCancelled) {
+          const detail = recordingStartError instanceof Error
+            ? recordingStartError.message
+            : 'Session recording unavailable';
+          const failedRecording = buildFailedRecording(detail);
+          setRecordingError(detail);
+          setSession((prev) => {
+            const updatedSession = {
+              ...prev,
+              recording: failedRecording,
+            };
+            sessionRef.current = updatedSession;
+            return updatedSession;
+          });
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsRecordingLoading(false);
+        }
+      }
+    };
+
+    void ensureRecording();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [applyRecordingCapability, buildFailedRecording, initialSession.date, initialSession.id, initialSession.status, restoredState?.session.status]);
+
+  useEffect(() => {
     onStateChange?.({
       session,
       currentStepIndex,
@@ -225,17 +314,61 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     setIsStepRunning(true);
   };
 
-  const handleFinishSession = () => {
+  const handleFinishSession = async () => {
     const now = Date.now();
     const finalSessionClock = isSessionRunning ? pauseTimer(sessionClockRef.current, now) : sessionClockRef.current;
     updateSessionClock(finalSessionClock);
     setSessionElapsed(getElapsedSeconds(finalSessionClock, now));
     setIsSessionRunning(false);
     setIsStepRunning(false);
+
+    let nextRecording = sessionRef.current.recording;
+    if (recordingCapability.canStop) {
+      setIsRecordingUpdating(true);
+      try {
+        const capability = await stopSessionRecording({
+          sessionId: sessionRef.current.id,
+          disposition: 'save',
+        });
+        nextRecording = applyRecordingCapability(capability) ?? nextRecording;
+      } catch (recordingStopError) {
+        const detail = recordingStopError instanceof Error
+          ? recordingStopError.message
+          : 'Unable to stop session recording';
+        nextRecording = buildFailedRecording(detail);
+        setRecordingError(detail);
+      } finally {
+        setIsRecordingUpdating(false);
+      }
+    }
+
     onCompleteSession({
-      ...session,
+      ...sessionRef.current,
       totalDurationSeconds: getElapsedSeconds(finalSessionClock, now),
+      recording: nextRecording,
     });
+  };
+
+  const handleCancel = async () => {
+    if (!window.confirm('Are you sure you want to cancel this session? Progress will not be saved.')) {
+      return;
+    }
+
+    if (recordingCapability.canStop) {
+      setIsRecordingUpdating(true);
+      try {
+        await stopSessionRecording({
+          sessionId: sessionRef.current.id,
+          disposition: 'discard',
+        });
+      } catch {
+        // Best effort only; cancelling the session still takes priority.
+      } finally {
+        setIsRecordingUpdating(false);
+      }
+    }
+
+    onCancel();
   };
 
   const currentStep = session.steps[currentStepIndex];
@@ -361,7 +494,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
           <span className="text-xs text-rose-300 ml-2 hidden sm:inline">Total elapsed time</span>
         </div>
         <button
-          onClick={onCancel}
+          onClick={handleCancel}
           className="p-1.5 hover:bg-rose-800 rounded-md transition-colors text-rose-300 hover:text-white"
         >
           <X size={18} />
@@ -403,8 +536,31 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
             </div>
           ) : null}
 
-          <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600 shadow-sm sm:flex-row sm:items-center sm:justify-between">
-            <span>{previewStatusMessage}</span>
+          <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600 shadow-sm">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <span>{previewStatusMessage}</span>
+              <div className="flex items-center gap-2 rounded-full bg-slate-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                <span className={`inline-block h-2 w-2 rounded-full ${recordingCapability.active ? 'bg-rose-500' : recordingError ? 'bg-amber-400' : recordingCapability.supported ? 'bg-slate-300' : 'bg-slate-200'}`} />
+                <span>
+                  {isRecordingLoading
+                    ? 'Starting recording'
+                    : isRecordingUpdating
+                    ? 'Finalising recording'
+                    : recordingCapability.active
+                    ? 'Recording session'
+                    : session.recording?.status === 'completed'
+                    ? 'Recording saved'
+                    : recordingError
+                    ? 'Recording issue'
+                    : recordingCapability.supported
+                    ? 'Recording idle'
+                    : 'Recording unavailable'}
+                </span>
+              </div>
+            </div>
+            {(recordingCapability.detail || recordingError) && (
+              <p className="text-[11px] text-slate-500 sm:max-w-[28rem]">{recordingError || recordingCapability.detail}</p>
+            )}
             <div className="flex flex-wrap items-center gap-2">
               <button
                 type="button"
@@ -555,7 +711,8 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
         {/* Finish Button */}
         <button
           onClick={handleFinishSession}
-          className="w-full flex items-center justify-center gap-2 bg-slate-800 hover:bg-slate-900 text-white p-5 rounded-3xl shadow-sm transition-colors text-lg font-bold"
+          disabled={isRecordingUpdating}
+          className="w-full flex items-center justify-center gap-2 bg-slate-800 hover:bg-slate-900 text-white p-5 rounded-3xl shadow-sm transition-colors text-lg font-bold disabled:cursor-not-allowed disabled:opacity-60"
         >
           <CheckCircle2 size={24} />
           Wrap Up Session

--- a/apps/brave-paws-app/src/components/ActiveSession.tsx
+++ b/apps/brave-paws-app/src/components/ActiveSession.tsx
@@ -8,6 +8,7 @@ import { TimerClock, getElapsedSeconds, getRemainingSeconds, pauseTimer, startTi
 import { ActiveSessionState } from '../utils/activeSessionStorage';
 import { reportClientDiagnostic } from '../utils/clientDiagnostics';
 import {
+  fetchSessionRecordingCapability,
   startSessionRecording,
   stopSessionRecording,
   UNSUPPORTED_SESSION_RECORDING_CAPABILITY,
@@ -140,7 +141,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
 
   const applyRecordingCapability = useCallback((capability: SessionRecordingCapability) => {
     setRecordingCapability(capability);
-    setRecordingError(capability.detail ?? null);
+    setRecordingError(null);
 
     if (!capability.recording) {
       return null;
@@ -235,13 +236,27 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     const ensureRecording = async () => {
       setIsRecordingLoading(true);
       try {
-        const capability = await startSessionRecording({
+        const capability = await fetchSessionRecordingCapability();
+        if (isCancelled) {
+          return;
+        }
+
+        applyRecordingCapability(capability);
+        if (!capability.supported || !capability.canStart) {
+          return;
+        }
+
+        if (capability.active && capability.sessionId === initialSession.id) {
+          return;
+        }
+
+        const startedCapability = await startSessionRecording({
           sessionId: initialSession.id,
           sessionDate: initialSession.date,
           sessionStatus: restoredState?.session.status ?? initialSession.status,
         });
         if (!isCancelled) {
-          applyRecordingCapability(capability);
+          applyRecordingCapability(startedCapability);
         }
       } catch (recordingStartError) {
         if (!isCancelled) {
@@ -377,6 +392,29 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
   const streamUrl = buildCameraStreamUrl(cameraUrl);
   const hasValidCameraUrl = streamUrl.length > 0;
   const activePreviewUrl = hasValidCameraUrl && isPreviewConnected ? streamUrl : '';
+  const recordingStatusLabel = isRecordingLoading
+    ? 'Starting recording'
+    : isRecordingUpdating
+    ? 'Finalising recording'
+    : recordingCapability.active
+    ? 'Recording session'
+    : session.recording?.status === 'completed'
+    ? 'Recording saved'
+    : !recordingCapability.supported
+    ? 'Recording unavailable'
+    : recordingError || session.recording?.status === 'failed'
+    ? 'Recording issue'
+    : recordingCapability.canStart
+    ? 'Recording idle'
+    : 'Recording unavailable';
+  const recordingIndicatorClass = recordingCapability.active
+    ? 'bg-rose-500'
+    : !recordingCapability.supported
+    ? 'bg-slate-200'
+    : recordingError || session.recording?.status === 'failed'
+    ? 'bg-amber-400'
+    : 'bg-slate-300';
+  const recordingDetailMessage = recordingError || session.recording?.detail || recordingCapability.detail;
 
   useEffect(() => {
     if (!hasValidCameraUrl) {
@@ -540,26 +578,12 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <span>{previewStatusMessage}</span>
               <div className="flex items-center gap-2 rounded-full bg-slate-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
-                <span className={`inline-block h-2 w-2 rounded-full ${recordingCapability.active ? 'bg-rose-500' : recordingError ? 'bg-amber-400' : recordingCapability.supported ? 'bg-slate-300' : 'bg-slate-200'}`} />
-                <span>
-                  {isRecordingLoading
-                    ? 'Starting recording'
-                    : isRecordingUpdating
-                    ? 'Finalising recording'
-                    : recordingCapability.active
-                    ? 'Recording session'
-                    : session.recording?.status === 'completed'
-                    ? 'Recording saved'
-                    : recordingError
-                    ? 'Recording issue'
-                    : recordingCapability.supported
-                    ? 'Recording idle'
-                    : 'Recording unavailable'}
-                </span>
+                <span className={`inline-block h-2 w-2 rounded-full ${recordingIndicatorClass}`} />
+                <span>{recordingStatusLabel}</span>
               </div>
             </div>
-            {(recordingCapability.detail || recordingError) && (
-              <p className="text-[11px] text-slate-500 sm:max-w-[28rem]">{recordingError || recordingCapability.detail}</p>
+            {recordingDetailMessage && (
+              <p className="text-[11px] text-slate-500 sm:max-w-[28rem]">{recordingDetailMessage}</p>
             )}
             <div className="flex flex-wrap items-center gap-2">
               <button

--- a/apps/brave-paws-app/src/components/Dashboard.tsx
+++ b/apps/brave-paws-app/src/components/Dashboard.tsx
@@ -155,14 +155,14 @@ export function Dashboard({
       {storageSync}
 
       <section className="bg-white rounded-3xl shadow-sm border border-slate-100 p-5 sm:p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Brave Paws v0.2.1</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Brave Paws v0.2.2</p>
         <div className="mt-2 flex items-start gap-3">
           <div className="rounded-2xl bg-rose-100 p-2.5 text-rose-500">
             <Server size={18} />
           </div>
           <p className="text-sm text-slate-500">
             Brave Paws now favours the local QUANTUM Tailnet setup: pairing-aware session sync, direct picam playback,
-            backend camera control, and no separate Windows streamer companion.
+            backend camera control, session recording, and no separate Windows streamer companion.
           </p>
         </div>
       </section>

--- a/apps/brave-paws-app/src/components/HistoryList.tsx
+++ b/apps/brave-paws-app/src/components/HistoryList.tsx
@@ -179,6 +179,11 @@ export function HistoryList({
                   <span className={`px-3 py-1 rounded-lg text-xs font-bold uppercase tracking-wider border ${getAnxietyColor(session.anxietyScore)}`}>
                     {getAnxietyLabel(session.anxietyScore)}
                   </span>
+                  {session.recording?.status === 'completed' && (
+                    <span className="px-3 py-1 rounded-lg text-xs font-bold uppercase tracking-wider border border-sky-200 bg-sky-50 text-sky-700">
+                      Recording
+                    </span>
+                  )}
                   {session.notes && (
                     <span className="text-sm text-slate-500 truncate flex-1 italic">"{session.notes}"</span>
                   )}

--- a/apps/brave-paws-app/src/components/SessionView.tsx
+++ b/apps/brave-paws-app/src/components/SessionView.tsx
@@ -163,6 +163,16 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave }
   };
 
   const anxietyInfo = getAnxietyLabel(session.anxietyScore);
+  const recordingStatusLabel =
+    session.recording?.status === 'recording'
+      ? 'Recording in progress'
+      : session.recording?.status === 'completed'
+      ? 'Recording saved'
+      : session.recording?.status === 'discarded'
+      ? 'Recording discarded'
+      : session.recording?.status === 'failed'
+      ? 'Recording issue'
+      : 'No recording';
 
   return (
     <div 
@@ -424,6 +434,32 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave }
           <p className="text-xl font-bold">{anxietyInfo.label}</p>
         </div>
       </div>
+
+      {session.recording && (
+        <div className="bg-white rounded-3xl shadow-sm border border-slate-100 p-6 sm:p-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-xs text-slate-500 font-bold uppercase tracking-widest">Session Recording</p>
+              <p className="mt-2 text-lg font-bold text-slate-800">{recordingStatusLabel}</p>
+              <p className="mt-1 text-sm text-slate-500">
+                {session.recording.hasAudio ? 'Video + audio archive.' : 'Video archive.'}
+                {session.recording.durationSeconds != null ? ` ${formatDuration(session.recording.durationSeconds)} captured.` : ''}
+                {session.recording.detail ? ` ${session.recording.detail}` : ''}
+              </p>
+            </div>
+            {session.recording.downloadPath && (
+              <a
+                href={session.recording.downloadPath}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center rounded-2xl bg-rose-50 px-4 py-3 text-sm font-bold text-rose-600 transition-colors hover:bg-rose-100"
+              >
+                Open recording
+              </a>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="bg-white rounded-3xl shadow-sm border border-slate-100 p-6 sm:p-8 h-[400px] flex flex-col">
         <h2 className="text-lg font-bold text-slate-800 mb-6">Step Durations</h2>

--- a/apps/brave-paws-app/src/types.ts
+++ b/apps/brave-paws-app/src/types.ts
@@ -7,6 +7,21 @@ export type Step = {
 };
 
 export type SessionStatus = 'pending' | 'completed' | 'aborted';
+export type SessionRecordingStatus = 'idle' | 'recording' | 'completed' | 'discarded' | 'failed';
+
+export type SessionRecording = {
+  status: SessionRecordingStatus;
+  sessionId: string | null;
+  provider: string;
+  startedAt?: string | null;
+  stoppedAt?: string | null;
+  hasAudio?: boolean;
+  relativeFilePath?: string | null;
+  downloadPath?: string | null;
+  durationSeconds?: number | null;
+  sizeBytes?: number | null;
+  detail?: string | null;
+};
 
 export type Session = {
   id: string;
@@ -18,4 +33,5 @@ export type Session = {
   anyoneHome?: string;
   notes?: string;
   status: SessionStatus;
+  recording?: SessionRecording;
 };

--- a/apps/brave-paws-app/src/utils/backendCapabilities.ts
+++ b/apps/brave-paws-app/src/utils/backendCapabilities.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '../config';
+import type { SessionRecording } from '../types';
 
 export type CameraStreamingCapability = {
   key: 'cameraStreaming';
@@ -10,8 +11,22 @@ export type CameraStreamingCapability = {
   detail: string | null;
 };
 
+export type SessionRecordingCapability = {
+  key: 'sessionRecording';
+  label: string;
+  provider: string;
+  supported: boolean;
+  canStart: boolean;
+  canStop: boolean;
+  active: boolean;
+  sessionId: string | null;
+  detail: string | null;
+  recording: SessionRecording | null;
+};
+
 export type BackendCapabilities = {
   cameraStreaming: CameraStreamingCapability;
+  sessionRecording: SessionRecordingCapability;
 };
 
 export const UNSUPPORTED_CAMERA_STREAMING_CAPABILITY: CameraStreamingCapability = {
@@ -22,6 +37,19 @@ export const UNSUPPORTED_CAMERA_STREAMING_CAPABILITY: CameraStreamingCapability 
   canSetEnabled: false,
   enabled: null,
   detail: 'This backend does not expose camera streaming control.',
+};
+
+export const UNSUPPORTED_SESSION_RECORDING_CAPABILITY: SessionRecordingCapability = {
+  key: 'sessionRecording',
+  label: 'Session recording',
+  provider: 'none',
+  supported: false,
+  canStart: false,
+  canStop: false,
+  active: false,
+  sessionId: null,
+  detail: 'This backend does not expose session recording.',
+  recording: null,
 };
 
 async function parseJsonResponse<T>(response: Response): Promise<T> {
@@ -55,4 +83,44 @@ export async function setCameraStreamingEnabled(
   });
 
   return parseJsonResponse<CameraStreamingCapability>(response);
+}
+
+export async function fetchSessionRecordingCapability(
+  fetchImpl: typeof fetch = fetch,
+  apiBaseUrl = getApiBaseUrl(),
+): Promise<SessionRecordingCapability> {
+  const response = await fetchImpl(`${apiBaseUrl}capabilities/recording`);
+  return parseJsonResponse<SessionRecordingCapability>(response);
+}
+
+export async function startSessionRecording(
+  payload: { sessionId: string; sessionDate?: string; sessionStatus?: string },
+  fetchImpl: typeof fetch = fetch,
+  apiBaseUrl = getApiBaseUrl(),
+): Promise<SessionRecordingCapability> {
+  const response = await fetchImpl(`${apiBaseUrl}recording/start`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  return parseJsonResponse<SessionRecordingCapability>(response);
+}
+
+export async function stopSessionRecording(
+  payload: { sessionId: string; disposition?: 'save' | 'discard' },
+  fetchImpl: typeof fetch = fetch,
+  apiBaseUrl = getApiBaseUrl(),
+): Promise<SessionRecordingCapability> {
+  const response = await fetchImpl(`${apiBaseUrl}recording/stop`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  return parseJsonResponse<SessionRecordingCapability>(response);
 }

--- a/apps/brave-paws-app/src/utils/sessionStatus.ts
+++ b/apps/brave-paws-app/src/utils/sessionStatus.ts
@@ -1,4 +1,4 @@
-import type { Session, SessionStatus, Step, StepStatus } from '../types';
+import type { Session, SessionRecording, SessionRecordingStatus, SessionStatus, Step, StepStatus } from '../types';
 
 export function isStepStatus(value: unknown): value is StepStatus {
   return value === 'pending' || value === 'completed' || value === 'aborted';
@@ -6,6 +6,10 @@ export function isStepStatus(value: unknown): value is StepStatus {
 
 export function isSessionStatus(value: unknown): value is SessionStatus {
   return value === 'pending' || value === 'completed' || value === 'aborted';
+}
+
+export function isSessionRecordingStatus(value: unknown): value is SessionRecordingStatus {
+  return value === 'idle' || value === 'recording' || value === 'completed' || value === 'discarded' || value === 'failed';
 }
 
 export function getStepStatusLabel(status: StepStatus): string {
@@ -96,6 +100,42 @@ export function normalizeStep(value: unknown): Step | null {
   };
 }
 
+function normalizeSessionRecording(value: unknown, sessionId: string): SessionRecording | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const status = isSessionRecordingStatus(candidate.status) ? candidate.status : undefined;
+  const provider = typeof candidate.provider === 'string' && candidate.provider.trim() ? candidate.provider : undefined;
+
+  if (!status || !provider) {
+    return undefined;
+  }
+
+  const sessionIdValue = typeof candidate.sessionId === 'string' && candidate.sessionId.trim()
+    ? candidate.sessionId
+    : sessionId;
+
+  return {
+    status,
+    sessionId: sessionIdValue,
+    provider,
+    startedAt: typeof candidate.startedAt === 'string' ? candidate.startedAt : null,
+    stoppedAt: typeof candidate.stoppedAt === 'string' ? candidate.stoppedAt : null,
+    hasAudio: typeof candidate.hasAudio === 'boolean' ? candidate.hasAudio : false,
+    relativeFilePath: typeof candidate.relativeFilePath === 'string' ? candidate.relativeFilePath : null,
+    downloadPath: typeof candidate.downloadPath === 'string' ? candidate.downloadPath : null,
+    durationSeconds: typeof candidate.durationSeconds === 'number' && Number.isFinite(candidate.durationSeconds)
+      ? Math.max(0, candidate.durationSeconds)
+      : null,
+    sizeBytes: typeof candidate.sizeBytes === 'number' && Number.isFinite(candidate.sizeBytes)
+      ? Math.max(0, candidate.sizeBytes)
+      : null,
+    detail: typeof candidate.detail === 'string' ? candidate.detail : null,
+  };
+}
+
 export function normalizeSession(value: unknown): Session | null {
   if (!value || typeof value !== 'object') {
     return null;
@@ -112,6 +152,7 @@ export function normalizeSession(value: unknown): Session | null {
     notes?: unknown;
     status?: unknown;
     completed?: unknown;
+    recording?: unknown;
   };
 
   if (typeof candidate.id !== 'string' || typeof candidate.date !== 'string' || !Array.isArray(candidate.steps)) {
@@ -160,6 +201,7 @@ export function normalizeSession(value: unknown): Session | null {
     anyoneHome: typeof candidate.anyoneHome === 'string' ? candidate.anyoneHome : '',
     notes: typeof candidate.notes === 'string' ? candidate.notes : '',
     status,
+    recording: normalizeSessionRecording(candidate.recording, candidate.id),
   };
 }
 

--- a/apps/brave-paws-app/tests/backend-capabilities.test.ts
+++ b/apps/brave-paws-app/tests/backend-capabilities.test.ts
@@ -3,8 +3,12 @@ import assert from 'node:assert/strict';
 
 import {
   fetchBackendCapabilities,
+  fetchSessionRecordingCapability,
   setCameraStreamingEnabled,
+  startSessionRecording,
+  stopSessionRecording,
   UNSUPPORTED_CAMERA_STREAMING_CAPABILITY,
+  UNSUPPORTED_SESSION_RECORDING_CAPABILITY,
 } from '../src/utils/backendCapabilities.ts';
 
 test('fetchBackendCapabilities reads the shared capabilities endpoint', async () => {
@@ -19,6 +23,15 @@ test('fetchBackendCapabilities reads the shared capabilities endpoint', async ()
         provider: 'command',
         detail: null,
       },
+      sessionRecording: {
+        ...UNSUPPORTED_SESSION_RECORDING_CAPABILITY,
+        supported: true,
+        canStart: true,
+        canStop: true,
+        active: false,
+        provider: 'command',
+        detail: null,
+      },
     }), {
       status: 200,
       headers: { 'content-type': 'application/json' },
@@ -28,6 +41,9 @@ test('fetchBackendCapabilities reads the shared capabilities endpoint', async ()
   assert.equal(capabilities.cameraStreaming.supported, true);
   assert.equal(capabilities.cameraStreaming.enabled, false);
   assert.equal(capabilities.cameraStreaming.provider, 'command');
+  assert.equal(capabilities.sessionRecording.supported, true);
+  assert.equal(capabilities.sessionRecording.canStart, true);
+  assert.equal(capabilities.sessionRecording.provider, 'command');
 });
 
 test('setCameraStreamingEnabled posts the desired enabled state to the shared capability endpoint', async () => {
@@ -52,4 +68,104 @@ test('setCameraStreamingEnabled posts the desired enabled state to the shared ca
 
   assert.equal(capability.enabled, true);
   assert.equal(capability.supported, true);
+});
+
+test('fetchSessionRecordingCapability reads the dedicated recording capability endpoint', async () => {
+  const capability = await fetchSessionRecordingCapability((async (input: string | URL | Request) => {
+    assert.equal(String(input), 'https://brave-paws.example/separation/api/capabilities/recording');
+    return new Response(JSON.stringify({
+      ...UNSUPPORTED_SESSION_RECORDING_CAPABILITY,
+      supported: true,
+      canStart: true,
+      canStop: true,
+      active: true,
+      sessionId: 'session-123',
+      provider: 'command',
+      recording: {
+        status: 'recording',
+        sessionId: 'session-123',
+        provider: 'command',
+        hasAudio: true,
+      },
+      detail: null,
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch, 'https://brave-paws.example/separation/api/');
+
+  assert.equal(capability.active, true);
+  assert.equal(capability.sessionId, 'session-123');
+  assert.equal(capability.recording?.status, 'recording');
+});
+
+test('startSessionRecording posts the session payload to the recording start endpoint', async () => {
+  const capability = await startSessionRecording(
+    { sessionId: 'session-abc', sessionDate: '2026-05-09T18:00:00.000Z', sessionStatus: 'pending' },
+    (async (input: string | URL | Request, init?: RequestInit) => {
+      assert.equal(String(input), 'https://brave-paws.example/separation/api/recording/start');
+      assert.equal(init?.method, 'POST');
+      assert.equal(init?.body, JSON.stringify({ sessionId: 'session-abc', sessionDate: '2026-05-09T18:00:00.000Z', sessionStatus: 'pending' }));
+
+      return new Response(JSON.stringify({
+        ...UNSUPPORTED_SESSION_RECORDING_CAPABILITY,
+        supported: true,
+        canStart: true,
+        canStop: true,
+        active: true,
+        sessionId: 'session-abc',
+        provider: 'command',
+        recording: {
+          status: 'recording',
+          sessionId: 'session-abc',
+          provider: 'command',
+        },
+        detail: null,
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch,
+    'https://brave-paws.example/separation/api/',
+  );
+
+  assert.equal(capability.active, true);
+  assert.equal(capability.sessionId, 'session-abc');
+});
+
+test('stopSessionRecording posts the stop payload to the recording stop endpoint', async () => {
+  const capability = await stopSessionRecording(
+    { sessionId: 'session-abc', disposition: 'save' },
+    (async (input: string | URL | Request, init?: RequestInit) => {
+      assert.equal(String(input), 'https://brave-paws.example/separation/api/recording/stop');
+      assert.equal(init?.method, 'POST');
+      assert.equal(init?.body, JSON.stringify({ sessionId: 'session-abc', disposition: 'save' }));
+
+      return new Response(JSON.stringify({
+        ...UNSUPPORTED_SESSION_RECORDING_CAPABILITY,
+        supported: true,
+        canStart: true,
+        canStop: true,
+        active: false,
+        sessionId: 'session-abc',
+        provider: 'command',
+        recording: {
+          status: 'completed',
+          sessionId: 'session-abc',
+          provider: 'command',
+          relativeFilePath: '2026/05/09/session-abc.mp4',
+          downloadPath: '/separation/api/recordings/file/2026/05/09/session-abc.mp4',
+        },
+        detail: null,
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch,
+    'https://brave-paws.example/separation/api/',
+  );
+
+  assert.equal(capability.active, false);
+  assert.equal(capability.recording?.status, 'completed');
+  assert.equal(capability.recording?.downloadPath, '/separation/api/recordings/file/2026/05/09/session-abc.mp4');
 });

--- a/apps/brave-paws-app/tests/dashboard-info-button.test.js
+++ b/apps/brave-paws-app/tests/dashboard-info-button.test.js
@@ -3,14 +3,15 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-test('Dashboard includes info entry points, camera control, and the v0.2.1 Tailnet note', () => {
+test('Dashboard includes info entry points, camera control, recording, and the v0.2.2 Tailnet note', () => {
   const dashboard = readFileSync(resolve(process.cwd(), 'src/components/Dashboard.tsx'), 'utf8');
 
   assert.match(dashboard, /recentSessions\.length === 0[\s\S]*New to separation anxiety training\?/);
   assert.match(dashboard, /recentSessions\.length > 0[\s\S]*About separation anxiety training/);
   assert.match(dashboard, /cameraStreamingControl/);
-  assert.match(dashboard, /Brave Paws v0\.2\.1/);
+  assert.match(dashboard, /Brave Paws v0\.2\.2/);
   assert.match(dashboard, /local QUANTUM Tailnet setup/);
   assert.match(dashboard, /backend camera control/);
+  assert.match(dashboard, /session recording/);
   assert.match(dashboard, /Windows streamer companion/);
 });

--- a/apps/brave-paws-app/tests/session-recording-ui.test.js
+++ b/apps/brave-paws-app/tests/session-recording-ui.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+test('session recording UI is surfaced during active sessions and in history/detail views', () => {
+  const activeSession = readFileSync(resolve(process.cwd(), 'src/components/ActiveSession.tsx'), 'utf8');
+  const sessionView = readFileSync(resolve(process.cwd(), 'src/components/SessionView.tsx'), 'utf8');
+  const historyList = readFileSync(resolve(process.cwd(), 'src/components/HistoryList.tsx'), 'utf8');
+
+  assert.match(activeSession, /Starting recording|Recording session|Recording saved|Recording unavailable/);
+  assert.match(activeSession, /startSessionRecording/);
+  assert.match(activeSession, /stopSessionRecording/);
+  assert.match(sessionView, /Session Recording/);
+  assert.match(sessionView, /Open recording/);
+  assert.match(historyList, /Recording/);
+});

--- a/apps/brave-paws-app/tests/session-recording-ui.test.js
+++ b/apps/brave-paws-app/tests/session-recording-ui.test.js
@@ -9,8 +9,10 @@ test('session recording UI is surfaced during active sessions and in history/det
   const historyList = readFileSync(resolve(process.cwd(), 'src/components/HistoryList.tsx'), 'utf8');
 
   assert.match(activeSession, /Starting recording|Recording session|Recording saved|Recording unavailable/);
+  assert.match(activeSession, /fetchSessionRecordingCapability/);
   assert.match(activeSession, /startSessionRecording/);
   assert.match(activeSession, /stopSessionRecording/);
+  assert.match(activeSession, /!recordingCapability\.supported\s*\?\s*'Recording unavailable'/);
   assert.match(sessionView, /Session Recording/);
   assert.match(sessionView, /Open recording/);
   assert.match(historyList, /Recording/);

--- a/apps/brave-paws-landing/index.html
+++ b/apps/brave-paws-landing/index.html
@@ -103,11 +103,11 @@
 
           <article class="panel product-panel tailnet-panel">
             <div class="section-heading compact">
-              <p class="eyebrow">Brave Paws v0.2.1</p>
+              <p class="eyebrow">Brave Paws v0.2.2</p>
               <h2>Safe public frontend, private pairing links, and same-origin picam access.</h2>
             </div>
             <p>
-              v0.2.1 keeps the local-first Tailnet architecture, adds backend-driven camera streaming control, and keeps the app HTTPS-friendly with pairing links plus a same-origin camera path in front of the live stream.
+              v0.2.2 keeps the local-first Tailnet architecture, adds backend-driven camera streaming control plus session recording, and keeps the app HTTPS-friendly with pairing links plus a same-origin camera path in front of the live stream.
             </p>
             <div class="architecture-card card">
               <div>

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -1,6 +1,6 @@
 # Brave Paws Server
 
-Brave Paws Server is the local-first backend for Brave Paws v0.2.1.
+Brave Paws Server is the local-first backend for Brave Paws v0.2.2.
 
 It serves three things from one localhost process:
 
@@ -35,10 +35,17 @@ It serves three things from one localhost process:
 | `BRAVE_PAWS_CAMERA_STATUS_COMMAND` | unset | Shell command that prints `on` / `off`, `true` / `false`, `1` / `0`, or JSON like `{"enabled":true}` |
 | `BRAVE_PAWS_CAMERA_ENABLE_COMMAND` | unset | Shell command that enables camera streaming when the command provider is active |
 | `BRAVE_PAWS_CAMERA_DISABLE_COMMAND` | unset | Shell command that disables camera streaming when the command provider is active |
+| `BRAVE_PAWS_RECORDING_PROVIDER` | `none` | Optional backend capability provider for session recording (`none` or `command`) |
+| `BRAVE_PAWS_RECORDING_LABEL` | `Session recording` | Friendly label returned by the recording capability API |
+| `BRAVE_PAWS_RECORDING_STATUS_COMMAND` | unset | Shell command that reports recording state as JSON or a simple `idle` / `recording` string |
+| `BRAVE_PAWS_RECORDING_START_COMMAND` | unset | Shell command that starts recording for the session id passed through Brave Paws env vars |
+| `BRAVE_PAWS_RECORDING_STOP_COMMAND` | unset | Shell command that stops/finalizes/discards recording for the session id passed through Brave Paws env vars |
 
 ## Storage
 
 Session data is stored as pretty JSON in `sessions.json` and mirrored to `brave_paws_sessions.csv` in the same directory so it stays easy to inspect, back up, and seed from a manual CSV drop.
+
+When session recording is enabled, finalized media files are expected under `<data dir>/recordings/`, and saved session objects can carry a lightweight `recording` pointer with metadata plus a backend download path.
 
 When pairing is enabled, opaque one-time camera pairing records are stored separately in `pairings.json`. Those links are meant to bootstrap a browser once; after the app resolves a token, it caches the resulting camera link locally and the token cannot be reused.
 
@@ -59,3 +66,16 @@ Brave Paws exposes a backend capability contract for camera streaming control:
 The built-in `command` provider is intentionally generic: the server only knows how to run configured shell commands and interpret the returned enabled/disabled state. That keeps the API backend-agnostic so a future provider can control something other than picam without changing the app contract.
 
 On QUANTUM, that generic contract is wired to Harvey's existing picam privacy-toggle skill through `deploy/scripts/brave-paws-picam-camera-control.sh`, which adapts the skill's `privacy_mode=...` output into the simple enabled/disabled signal expected by the API.
+
+## Session recording API
+
+Brave Paws also exposes a session recording contract that is intentionally separate from both the HLS preview path and the Icecast audio path:
+
+- `GET /separation/api/capabilities/recording` → returns recording capability and current state
+- `POST /separation/api/recording/start` with `{ "sessionId": "...", "sessionDate": "...", "sessionStatus": "..." }` → starts or resumes recording for a session
+- `POST /separation/api/recording/stop` with `{ "sessionId": "...", "disposition": "save" | "discard" }` → finalizes or discards the session recording
+- `GET /separation/api/recordings/file/<relative-path>` → streams a finalized recording file from the canonical recordings directory
+
+The intended deployment model is a passive extra reader near the media source: the live RTSP publisher remains the same, the in-app HLS preview remains the same, and the Icecast audio stream remains the same. Recording should read the source RTSP feed separately and avoid inserting transcoding or buffering into the live user-facing paths.
+
+On QUANTUM, the sample wiring for this contract lives in `deploy/scripts/brave-paws-picam-recording-control.sh`. It SSHes to `picam`, starts a passive localhost RTSP reader there, finalizes the capture, and places the canonical file under the Brave Paws recordings directory on QUANTUM after stop.

--- a/apps/brave-paws-server/src/config.ts
+++ b/apps/brave-paws-server/src/config.ts
@@ -43,6 +43,7 @@ export type BravePawsServerConfig = {
   appDistDir: string;
   dataDir: string;
   dataFilePath: string;
+  recordingsDir: string;
   pairingStoreFilePath: string;
   pairingEnabled: boolean;
   cameraUpstreamBaseUrl: string;
@@ -51,6 +52,11 @@ export type BravePawsServerConfig = {
   cameraControlStatusCommand: string | null;
   cameraControlEnableCommand: string | null;
   cameraControlDisableCommand: string | null;
+  recordingProvider: 'none' | 'command';
+  recordingLabel: string;
+  recordingStatusCommand: string | null;
+  recordingStartCommand: string | null;
+  recordingStopCommand: string | null;
   authToken: string | null;
 };
 
@@ -75,6 +81,7 @@ export function resolveConfig(env = process.env): BravePawsServerConfig {
     appDistDir: path.resolve(env.BRAVE_PAWS_APP_DIST_DIR || path.join(repoRoot, 'apps', 'brave-paws-app', 'dist')),
     dataDir,
     dataFilePath: path.join(dataDir, 'sessions.json'),
+    recordingsDir: path.join(dataDir, 'recordings'),
     pairingStoreFilePath: path.resolve(env.BRAVE_PAWS_PAIRING_STORE_FILE || path.join(dataDir, 'pairings.json')),
     pairingEnabled: env.BRAVE_PAWS_ENABLE_PAIRING === 'true',
     cameraUpstreamBaseUrl: (env.BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL || 'http://127.0.0.1:18888/').replace(/\/?$/, '/'),
@@ -83,6 +90,11 @@ export function resolveConfig(env = process.env): BravePawsServerConfig {
     cameraControlStatusCommand: env.BRAVE_PAWS_CAMERA_STATUS_COMMAND?.trim() || null,
     cameraControlEnableCommand: env.BRAVE_PAWS_CAMERA_ENABLE_COMMAND?.trim() || null,
     cameraControlDisableCommand: env.BRAVE_PAWS_CAMERA_DISABLE_COMMAND?.trim() || null,
+    recordingProvider: env.BRAVE_PAWS_RECORDING_PROVIDER === 'command' ? 'command' : 'none',
+    recordingLabel: env.BRAVE_PAWS_RECORDING_LABEL || 'Session recording',
+    recordingStatusCommand: env.BRAVE_PAWS_RECORDING_STATUS_COMMAND?.trim() || null,
+    recordingStartCommand: env.BRAVE_PAWS_RECORDING_START_COMMAND?.trim() || null,
+    recordingStopCommand: env.BRAVE_PAWS_RECORDING_STOP_COMMAND?.trim() || null,
     authToken: env.BRAVE_PAWS_AUTH_TOKEN || null,
   };
 }

--- a/apps/brave-paws-server/src/recordingControl.ts
+++ b/apps/brave-paws-server/src/recordingControl.ts
@@ -1,0 +1,420 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { BravePawsServerConfig } from './config.js';
+import type { SessionRecording } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+type RecordingCommandKind = 'status' | 'start' | 'stop';
+
+type RecordingCommandPayload = {
+  sessionId?: string;
+  sessionDate?: string;
+  sessionStatus?: string;
+  disposition?: 'save' | 'discard';
+};
+
+export type SessionRecordingCapability = {
+  key: 'sessionRecording';
+  label: string;
+  provider: string;
+  supported: boolean;
+  canStart: boolean;
+  canStop: boolean;
+  active: boolean;
+  sessionId: string | null;
+  detail: string | null;
+  recording: SessionRecording | null;
+};
+
+export interface SessionRecordingController {
+  getCapability(): Promise<SessionRecordingCapability>;
+  startRecording(payload: RecordingCommandPayload): Promise<SessionRecordingCapability>;
+  stopRecording(payload: RecordingCommandPayload): Promise<SessionRecordingCapability>;
+}
+
+class RecordingCommandError extends Error {
+  constructor(
+    message: string,
+    readonly safeDetail: string,
+  ) {
+    super(message);
+    this.name = 'RecordingCommandError';
+  }
+}
+
+function toShellString(command: string | null | undefined): string | null {
+  const trimmed = command?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function getCommandFailureDetail(kind: RecordingCommandKind): string {
+  if (kind === 'status') {
+    return 'Session recording status unavailable.';
+  }
+
+  return kind === 'start'
+    ? 'Unable to start session recording right now.'
+    : 'Unable to stop session recording right now.';
+}
+
+function getSafeCommandErrorDetail(error: unknown, fallback: string): string {
+  if (error instanceof RecordingCommandError) {
+    return error.safeDetail;
+  }
+
+  return fallback;
+}
+
+async function runShellCommand(command: string, kind: RecordingCommandKind, envOverrides: Record<string, string>) {
+  try {
+    return await execFileAsync('/bin/sh', ['-c', command], {
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024,
+      env: {
+        ...process.env,
+        ...envOverrides,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Command failed';
+    throw new RecordingCommandError(message, getCommandFailureDetail(kind));
+  }
+}
+
+function normalizeRecording(value: unknown, provider: string, fallbackSessionId: string | null): SessionRecording | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const status =
+    candidate.status === 'idle' ||
+    candidate.status === 'recording' ||
+    candidate.status === 'completed' ||
+    candidate.status === 'discarded' ||
+    candidate.status === 'failed'
+      ? candidate.status
+      : null;
+
+  if (!status) {
+    return null;
+  }
+
+  return {
+    status,
+    sessionId: typeof candidate.sessionId === 'string' ? candidate.sessionId : fallbackSessionId,
+    provider,
+    startedAt: typeof candidate.startedAt === 'string' ? candidate.startedAt : null,
+    stoppedAt: typeof candidate.stoppedAt === 'string' ? candidate.stoppedAt : null,
+    hasAudio: typeof candidate.hasAudio === 'boolean' ? candidate.hasAudio : false,
+    relativeFilePath: typeof candidate.relativeFilePath === 'string' ? candidate.relativeFilePath : null,
+    downloadPath: typeof candidate.downloadPath === 'string' ? candidate.downloadPath : null,
+    durationSeconds:
+      typeof candidate.durationSeconds === 'number' && Number.isFinite(candidate.durationSeconds)
+        ? Math.max(0, candidate.durationSeconds)
+        : null,
+    sizeBytes:
+      typeof candidate.sizeBytes === 'number' && Number.isFinite(candidate.sizeBytes)
+        ? Math.max(0, candidate.sizeBytes)
+        : null,
+    detail: typeof candidate.detail === 'string' ? candidate.detail : null,
+  };
+}
+
+function parseJsonCapability(raw: string, label: string, provider: string): SessionRecordingCapability | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    const recording = normalizeRecording(parsed.recording ?? parsed, provider, typeof parsed.sessionId === 'string' ? parsed.sessionId : null);
+    const active = typeof parsed.active === 'boolean'
+      ? parsed.active
+      : recording?.status === 'recording';
+    const sessionId = typeof parsed.sessionId === 'string'
+      ? parsed.sessionId
+      : recording?.sessionId ?? null;
+
+    return {
+      key: 'sessionRecording',
+      label,
+      provider,
+      supported: typeof parsed.supported === 'boolean' ? parsed.supported : true,
+      canStart: typeof parsed.canStart === 'boolean' ? parsed.canStart : true,
+      canStop: typeof parsed.canStop === 'boolean' ? parsed.canStop : true,
+      active: Boolean(active),
+      sessionId,
+      detail: typeof parsed.detail === 'string' ? parsed.detail : recording?.detail ?? null,
+      recording,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseFallbackCapability(raw: string, label: string, provider: string): SessionRecordingCapability | null {
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  if (['idle', 'off', 'inactive', 'stopped'].includes(normalized)) {
+    return {
+      key: 'sessionRecording',
+      label,
+      provider,
+      supported: true,
+      canStart: true,
+      canStop: true,
+      active: false,
+      sessionId: null,
+      detail: null,
+      recording: null,
+    };
+  }
+
+  if (['recording', 'active', 'running', 'on'].includes(normalized)) {
+    return {
+      key: 'sessionRecording',
+      label,
+      provider,
+      supported: true,
+      canStart: true,
+      canStop: true,
+      active: true,
+      sessionId: null,
+      detail: null,
+      recording: {
+        status: 'recording',
+        sessionId: null,
+        provider,
+        detail: null,
+      },
+    };
+  }
+
+  return null;
+}
+
+function parseCapabilityOutput(raw: string, label: string, provider: string): SessionRecordingCapability {
+  return (
+    parseJsonCapability(raw, label, provider)
+    ?? parseFallbackCapability(raw, label, provider)
+    ?? {
+      key: 'sessionRecording',
+      label,
+      provider,
+      supported: true,
+      canStart: true,
+      canStop: true,
+      active: false,
+      sessionId: null,
+      detail: 'Session recording status is available but could not be parsed.',
+      recording: null,
+    }
+  );
+}
+
+function buildCapability(options: {
+  label: string;
+  provider: string;
+  supported: boolean;
+  canStart: boolean;
+  canStop: boolean;
+  active?: boolean;
+  sessionId?: string | null;
+  detail?: string | null;
+  recording?: SessionRecording | null;
+}): SessionRecordingCapability {
+  return {
+    key: 'sessionRecording',
+    label: options.label,
+    provider: options.provider,
+    supported: options.supported,
+    canStart: options.canStart,
+    canStop: options.canStop,
+    active: options.active ?? false,
+    sessionId: options.sessionId ?? null,
+    detail: options.detail ?? null,
+    recording: options.recording ?? null,
+  };
+}
+
+function buildRecordingEnv(config: BravePawsServerConfig, payload: RecordingCommandPayload = {}): Record<string, string> {
+  return {
+    BRAVE_PAWS_DATA_DIR: config.dataDir,
+    BRAVE_PAWS_RECORDINGS_DIR: config.recordingsDir,
+    BRAVE_PAWS_RECORDING_SESSION_ID: payload.sessionId || '',
+    BRAVE_PAWS_RECORDING_SESSION_DATE: payload.sessionDate || '',
+    BRAVE_PAWS_RECORDING_SESSION_STATUS: payload.sessionStatus || '',
+    BRAVE_PAWS_RECORDING_DISPOSITION: payload.disposition || 'save',
+  };
+}
+
+class UnsupportedSessionRecordingController implements SessionRecordingController {
+  constructor(
+    private readonly options: {
+      label: string;
+      provider: string;
+      detail: string;
+    },
+  ) {}
+
+  async getCapability(): Promise<SessionRecordingCapability> {
+    return buildCapability({
+      label: this.options.label,
+      provider: this.options.provider,
+      supported: false,
+      canStart: false,
+      canStop: false,
+      detail: this.options.detail,
+    });
+  }
+
+  async startRecording(): Promise<SessionRecordingCapability> {
+    return this.getCapability();
+  }
+
+  async stopRecording(): Promise<SessionRecordingCapability> {
+    return this.getCapability();
+  }
+}
+
+class CommandSessionRecordingController implements SessionRecordingController {
+  private operationQueue = Promise.resolve();
+
+  constructor(
+    private readonly options: {
+      config: BravePawsServerConfig;
+      label: string;
+      provider: string;
+      statusCommand: string;
+      startCommand: string;
+      stopCommand: string;
+    },
+  ) {}
+
+  private async runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.operationQueue.then(operation, operation);
+    this.operationQueue = result.then(() => undefined, () => undefined);
+    return result;
+  }
+
+  private async readCapability(payload: RecordingCommandPayload = {}, detailOverride: string | null = null): Promise<SessionRecordingCapability> {
+    try {
+      const result = await runShellCommand(
+        this.options.statusCommand,
+        'status',
+        buildRecordingEnv(this.options.config, payload),
+      );
+      const capability = parseCapabilityOutput(result.stdout, this.options.label, this.options.provider);
+      return {
+        ...capability,
+        detail: detailOverride ?? capability.detail,
+      };
+    } catch (error) {
+      console.error('Session recording status command failed', error);
+      return buildCapability({
+        label: this.options.label,
+        provider: this.options.provider,
+        supported: true,
+        canStart: true,
+        canStop: true,
+        active: false,
+        sessionId: payload.sessionId ?? null,
+        detail: detailOverride ?? getSafeCommandErrorDetail(error, 'Session recording status unavailable.'),
+      });
+    }
+  }
+
+  async getCapability(): Promise<SessionRecordingCapability> {
+    return this.readCapability();
+  }
+
+  async startRecording(payload: RecordingCommandPayload): Promise<SessionRecordingCapability> {
+    return this.runExclusive(async () => {
+      try {
+        const result = await runShellCommand(
+          this.options.startCommand,
+          'start',
+          buildRecordingEnv(this.options.config, payload),
+        );
+        const capability = parseCapabilityOutput(result.stdout, this.options.label, this.options.provider);
+        return capability;
+      } catch (error) {
+        console.error('Session recording start command failed', error);
+        return this.readCapability(payload, getSafeCommandErrorDetail(error, getCommandFailureDetail('start')));
+      }
+    });
+  }
+
+  async stopRecording(payload: RecordingCommandPayload): Promise<SessionRecordingCapability> {
+    return this.runExclusive(async () => {
+      try {
+        const result = await runShellCommand(
+          this.options.stopCommand,
+          'stop',
+          buildRecordingEnv(this.options.config, payload),
+        );
+        const capability = parseCapabilityOutput(result.stdout, this.options.label, this.options.provider);
+        return capability;
+      } catch (error) {
+        console.error('Session recording stop command failed', error);
+        return this.readCapability(payload, getSafeCommandErrorDetail(error, getCommandFailureDetail('stop')));
+      }
+    });
+  }
+}
+
+function getMissingCommandNames(commands: {
+  statusCommand: string | null;
+  startCommand: string | null;
+  stopCommand: string | null;
+}) {
+  return [
+    commands.statusCommand ? null : 'status',
+    commands.startCommand ? null : 'start',
+    commands.stopCommand ? null : 'stop',
+  ].filter((value): value is 'status' | 'start' | 'stop' => value != null);
+}
+
+export function createSessionRecordingController(config: BravePawsServerConfig): SessionRecordingController {
+  const statusCommand = toShellString(config.recordingStatusCommand);
+  const startCommand = toShellString(config.recordingStartCommand);
+  const stopCommand = toShellString(config.recordingStopCommand);
+
+  if (config.recordingProvider === 'command') {
+    const missingCommands = getMissingCommandNames({
+      statusCommand,
+      startCommand,
+      stopCommand,
+    });
+
+    if (!missingCommands.length) {
+      return new CommandSessionRecordingController({
+        config,
+        label: config.recordingLabel,
+        provider: config.recordingProvider,
+        statusCommand: statusCommand!,
+        startCommand: startCommand!,
+        stopCommand: stopCommand!,
+      });
+    }
+
+    return new UnsupportedSessionRecordingController({
+      label: config.recordingLabel,
+      provider: config.recordingProvider,
+      detail: `Session recording command provider is misconfigured: missing ${missingCommands.join(', ')} command${missingCommands.length === 1 ? '' : 's'}.`,
+    });
+  }
+
+  return new UnsupportedSessionRecordingController({
+    label: config.recordingLabel,
+    provider: 'none',
+    detail: 'This backend does not expose session recording.',
+  });
+}

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -473,9 +473,24 @@ async function serveRecordingFile(
 ) {
   const prefix = `${config.apiBasePath}recordings/file/`;
   const encodedSegments = pathname.slice(prefix.length).split('/').filter(Boolean);
-  const safeSegments = encodedSegments
-    .map((segment) => decodeURIComponent(segment))
-    .filter((segment) => segment && segment !== '.' && segment !== '..' && !segment.includes('..'));
+  const decodedSegments: string[] = [];
+
+  for (const segment of encodedSegments) {
+    try {
+      decodedSegments.push(decodeURIComponent(segment));
+    } catch {
+      sendJson(response, 400, {
+        error: 'Invalid recording path',
+      });
+      return;
+    }
+  }
+
+  const safeSegments = decodedSegments.filter((segment) => segment && segment !== '.' && segment !== '..' && !segment.includes('..'));
+  if (safeSegments.length !== decodedSegments.length) {
+    notFound(response);
+    return;
+  }
 
   const resolvedPath = path.resolve(config.recordingsDir, ...safeSegments);
   const relativeResolved = path.relative(config.recordingsDir, resolvedPath);
@@ -601,6 +616,11 @@ async function handleApiRequest(
   }
 
   if (request.method === 'GET' && pathname.startsWith(recordingFilePathPrefix)) {
+    if (!isWriteAuthorized(request, config)) {
+      sendJson(response, 401, { error: 'Unauthorized' });
+      return;
+    }
+
     await serveRecordingFile(response, pathname, config);
     return;
   }

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -11,6 +11,11 @@ import {
   type CameraStreamingController,
 } from './cameraControl.js';
 import {
+  createSessionRecordingController,
+  type SessionRecordingCapability,
+  type SessionRecordingController,
+} from './recordingControl.js';
+import {
   buildPairingAppUrl,
   consumePairing,
   createPairing,
@@ -139,6 +144,8 @@ function getMimeType(filePath: string): string {
   if (filePath.endsWith('.png')) return 'image/png';
   if (filePath.endsWith('.jpg') || filePath.endsWith('.jpeg')) return 'image/jpeg';
   if (filePath.endsWith('.woff2')) return 'font/woff2';
+  if (filePath.endsWith('.mp4')) return 'video/mp4';
+  if (filePath.endsWith('.mkv')) return 'video/x-matroska';
   return 'application/octet-stream';
 }
 
@@ -404,7 +411,7 @@ async function proxyCameraRequest(
       method: request.method,
       headers: {
         accept: request.headers.accept || '*/*',
-        'user-agent': request.headers['user-agent'] || 'BravePawsServer/0.2.1',
+        'user-agent': request.headers['user-agent'] || 'BravePawsServer/0.2.2',
       },
     });
 
@@ -433,15 +440,69 @@ async function proxyCameraRequest(
   }
 }
 
+function buildRecordingDownloadPath(apiBasePath: string, relativeFilePath: string | null | undefined): string | null {
+  if (!relativeFilePath) {
+    return null;
+  }
+
+  return `${apiBasePath}recordings/file/${relativeFilePath
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')}`;
+}
+
+function attachRecordingDownloadPath(apiBasePath: string, capability: SessionRecordingCapability): SessionRecordingCapability {
+  if (!capability.recording?.relativeFilePath) {
+    return capability;
+  }
+
+  return {
+    ...capability,
+    recording: {
+      ...capability.recording,
+      downloadPath: buildRecordingDownloadPath(apiBasePath, capability.recording.relativeFilePath),
+    },
+  };
+}
+
+async function serveRecordingFile(
+  response: ServerResponse,
+  pathname: string,
+  config: BravePawsServerConfig,
+) {
+  const prefix = `${config.apiBasePath}recordings/file/`;
+  const encodedSegments = pathname.slice(prefix.length).split('/').filter(Boolean);
+  const safeSegments = encodedSegments
+    .map((segment) => decodeURIComponent(segment))
+    .filter((segment) => segment && segment !== '.' && segment !== '..' && !segment.includes('..'));
+
+  const resolvedPath = path.resolve(config.recordingsDir, ...safeSegments);
+  const relativeResolved = path.relative(config.recordingsDir, resolvedPath);
+  if (relativeResolved.startsWith('..') || path.isAbsolute(relativeResolved)) {
+    notFound(response);
+    return;
+  }
+
+  if (!(await fileExists(resolvedPath))) {
+    notFound(response, 'Recording not found');
+    return;
+  }
+
+  await serveStaticFile(response, resolvedPath);
+}
+
 async function handleApiRequest(
   request: IncomingMessage,
   response: ServerResponse,
   pathname: string,
   config: BravePawsServerConfig,
   cameraStreamingController: CameraStreamingController,
+  sessionRecordingController: SessionRecordingController,
 ) {
   const capabilitiesPath = `${config.apiBasePath}capabilities`;
   const cameraStreamingCapabilityPath = `${capabilitiesPath}/camera-streaming`;
+  const sessionRecordingCapabilityPath = `${capabilitiesPath}/recording`;
 
   if (pathname === config.healthPath) {
     const store = await readSessionStore(config.dataFilePath);
@@ -466,10 +527,16 @@ async function handleApiRequest(
   const syncPushPath = `${config.apiBasePath}sync/push`;
   const clientDiagnosticsPath = config.clientDiagnosticsPath;
   const pairingCollectionPath = `${config.apiBasePath}pairings`;
+  const recordingStartPath = `${config.apiBasePath}recording/start`;
+  const recordingStopPath = `${config.apiBasePath}recording/stop`;
+  const recordingFilePathPrefix = `${config.apiBasePath}recordings/file/`;
 
   if (request.method === 'GET' && pathname === capabilitiesPath) {
     const capabilities = await getBackendCapabilities(cameraStreamingController);
-    sendJson(response, 200, capabilities);
+    sendJson(response, 200, {
+      ...capabilities,
+      sessionRecording: attachRecordingDownloadPath(config.apiBasePath, await sessionRecordingController.getCapability()),
+    });
     return;
   }
 
@@ -494,6 +561,48 @@ async function handleApiRequest(
       sendJson(response, 200, await cameraStreamingController.setEnabled(payload.enabled));
       return;
     }
+  }
+
+  if (request.method === 'GET' && pathname === sessionRecordingCapabilityPath) {
+    sendJson(response, 200, attachRecordingDownloadPath(config.apiBasePath, await sessionRecordingController.getCapability()));
+    return;
+  }
+
+  if (request.method === 'POST' && pathname === recordingStartPath) {
+    if (!isWriteAuthorized(request, config)) {
+      sendJson(response, 401, { error: 'Unauthorized' });
+      return;
+    }
+
+    const payload = await readJsonBody<{ sessionId?: string; sessionDate?: string; sessionStatus?: string }>(request);
+    if (!payload.sessionId) {
+      sendJson(response, 400, { error: 'sessionId is required' });
+      return;
+    }
+
+    sendJson(response, 200, attachRecordingDownloadPath(config.apiBasePath, await sessionRecordingController.startRecording(payload)));
+    return;
+  }
+
+  if (request.method === 'POST' && pathname === recordingStopPath) {
+    if (!isWriteAuthorized(request, config)) {
+      sendJson(response, 401, { error: 'Unauthorized' });
+      return;
+    }
+
+    const payload = await readJsonBody<{ sessionId?: string; disposition?: 'save' | 'discard' }>(request);
+    if (!payload.sessionId) {
+      sendJson(response, 400, { error: 'sessionId is required' });
+      return;
+    }
+
+    sendJson(response, 200, attachRecordingDownloadPath(config.apiBasePath, await sessionRecordingController.stopRecording(payload)));
+    return;
+  }
+
+  if (request.method === 'GET' && pathname.startsWith(recordingFilePathPrefix)) {
+    await serveRecordingFile(response, pathname, config);
+    return;
   }
 
   if (request.method === 'GET' && pathname === sessionsCollectionPath) {
@@ -668,6 +777,7 @@ async function handleApiRequest(
 
 export function createBravePawsServer(config = resolveConfig()) {
   const cameraStreamingController = createCameraStreamingController(config);
+  const sessionRecordingController = createSessionRecordingController(config);
 
   const server = http.createServer(async (request, response) => {
     try {
@@ -711,7 +821,7 @@ export function createBravePawsServer(config = resolveConfig()) {
       }
 
       if (pathname.startsWith(config.apiBasePath)) {
-        await handleApiRequest(request, response, pathname, config, cameraStreamingController);
+        await handleApiRequest(request, response, pathname, config, cameraStreamingController, sessionRecordingController);
         return;
       }
 
@@ -757,6 +867,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const config = resolveConfig();
   const server = createBravePawsServer(config);
   const startupCameraStreamingController = createCameraStreamingController(config);
+  const startupSessionRecordingController = createSessionRecordingController(config);
 
   server.listen(config.port, config.host, () => {
     const publicHint = config.publicBaseUrl
@@ -783,6 +894,21 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       }
     }).catch((error: unknown) => {
       console.warn('Camera streaming control startup check failed.', error);
+    });
+    void startupSessionRecordingController.getCapability().then((capability: SessionRecordingCapability) => {
+      if (capability.provider === 'command') {
+        if (capability.supported && capability.canStart && capability.canStop) {
+          console.log(`Session recording control: ${capability.label}`);
+          if (capability.detail) {
+            console.warn(capability.detail);
+          }
+          return;
+        }
+
+        console.warn(capability.detail || 'Session recording command provider is configured but unavailable.');
+      }
+    }).catch((error: unknown) => {
+      console.warn('Session recording startup check failed.', error);
     });
     if (config.pairingEnabled) {
       console.log(`Pairing broker: http://${config.host}:${config.port}${config.apiBasePath}pairings`);

--- a/apps/brave-paws-server/src/types.ts
+++ b/apps/brave-paws-server/src/types.ts
@@ -7,6 +7,21 @@ export type Step = {
 };
 
 export type SessionStatus = 'pending' | 'completed' | 'aborted';
+export type SessionRecordingStatus = 'idle' | 'recording' | 'completed' | 'discarded' | 'failed';
+
+export type SessionRecording = {
+  status: SessionRecordingStatus;
+  sessionId: string | null;
+  provider: string;
+  startedAt?: string | null;
+  stoppedAt?: string | null;
+  hasAudio?: boolean;
+  relativeFilePath?: string | null;
+  downloadPath?: string | null;
+  durationSeconds?: number | null;
+  sizeBytes?: number | null;
+  detail?: string | null;
+};
 
 export type Session = {
   id: string;
@@ -18,4 +33,5 @@ export type Session = {
   anyoneHome?: string;
   notes?: string;
   status: SessionStatus;
+  recording?: SessionRecording;
 };

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -22,7 +22,7 @@ async function close(server: http.Server) {
   await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
 }
 
-async function requestRaw(baseUrl: string, requestPath: string) {
+async function requestRaw(baseUrl: string, requestPath: string, headers?: http.OutgoingHttpHeaders) {
   const url = new URL(baseUrl);
 
   return new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
@@ -32,6 +32,7 @@ async function requestRaw(baseUrl: string, requestPath: string) {
         port: url.port,
         path: requestPath,
         method: 'GET',
+        headers,
       },
       (response) => {
         const chunks: Buffer[] = [];
@@ -210,6 +211,41 @@ test('session recording capability can be started and stopped through the comman
       recordingStatusCommand: `python3 - <<'PY'\nimport json, os\nstate_file = ${JSON.stringify(stateFilePath)}\nif not os.path.exists(state_file):\n    print(json.dumps({"active": False, "sessionId": None, "recording": None}))\nelse:\n    print(open(state_file, 'r', encoding='utf8').read())\nPY`,
       recordingStartCommand: `python3 - <<'PY'\nimport json, os\nstate_file = ${JSON.stringify(stateFilePath)}\npayload = {"active": True, "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "recording": {"status": "recording", "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "startedAt": "2026-05-09T18:00:00.000Z", "hasAudio": True}}\nos.makedirs(os.path.dirname(state_file), exist_ok=True)\nopen(state_file, 'w', encoding='utf8').write(json.dumps(payload))\nprint(json.dumps(payload))\nPY`,
       recordingStopCommand: `python3 - <<'PY'\nimport json, os\nstate_file = ${JSON.stringify(stateFilePath)}\npayload = {"active": False, "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "recording": {"status": "completed", "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "startedAt": "2026-05-09T18:00:00.000Z", "stoppedAt": "2026-05-09T18:12:00.000Z", "hasAudio": True, "relativeFilePath": "2026/05/09/session-123.mp4", "durationSeconds": 720, "sizeBytes": 19}}\nos.makedirs(os.path.dirname(state_file), exist_ok=True)\nopen(state_file, 'w', encoding='utf8').write(json.dumps(payload))\nprint(json.dumps(payload))\nPY`,
+    });
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('recording download rejects malformed path segments instead of crashing', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await requestRaw(baseUrl, '/separation/api/recordings/file/%E0%A4%A');
+    assert.equal(response.statusCode, 400);
+    assert.match(response.body, /Invalid recording path/);
+  });
+});
+
+test('recording download requires auth when an auth token is configured', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-recording-auth-'));
+  const recordingDir = path.join(tempDir, 'recordings');
+  const relativeRecordingPath = '2026/05/09/secure-session.mp4';
+
+  try {
+    await fs.mkdir(path.join(recordingDir, '2026/05/09'), { recursive: true });
+    await fs.writeFile(path.join(recordingDir, relativeRecordingPath), 'secure recording payload');
+
+    await withFixtureServer(async ({ baseUrl }) => {
+      const unauthenticated = await requestRaw(baseUrl, `/separation/api/recordings/file/${relativeRecordingPath}`);
+      assert.equal(unauthenticated.statusCode, 401);
+
+      const authenticated = await requestRaw(baseUrl, `/separation/api/recordings/file/${relativeRecordingPath}`, {
+        'x-brave-paws-token': 'secret-token',
+      });
+      assert.equal(authenticated.statusCode, 200);
+      assert.equal(authenticated.body, 'secure recording payload');
+    }, {
+      authToken: 'secret-token',
+      recordingsDir: recordingDir,
     });
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -93,7 +93,13 @@ async function withFixtureServer(
     cameraControlStatusCommand: null,
     cameraControlEnableCommand: null,
     cameraControlDisableCommand: null,
+    recordingProvider: 'none',
+    recordingLabel: 'Session recording',
+    recordingStatusCommand: null,
+    recordingStartCommand: null,
+    recordingStopCommand: null,
     authToken: null,
+    recordingsDir: path.join(dataDir, 'recordings'),
     ...configOverrides,
   };
 
@@ -126,11 +132,88 @@ test('camera capabilities report unsupported control by default', async () => {
   await withFixtureServer(async ({ baseUrl }) => {
     const response = await fetch(`${baseUrl}/separation/api/capabilities`);
     assert.equal(response.status, 200);
-    const body = await response.json() as { cameraStreaming: { supported: boolean; canSetEnabled: boolean; enabled: boolean | null } };
+    const body = await response.json() as {
+      cameraStreaming: { supported: boolean; canSetEnabled: boolean; enabled: boolean | null };
+      sessionRecording: { supported: boolean; canStart: boolean; canStop: boolean; active: boolean };
+    };
     assert.equal(body.cameraStreaming.supported, false);
     assert.equal(body.cameraStreaming.canSetEnabled, false);
     assert.equal(body.cameraStreaming.enabled, null);
+    assert.equal(body.sessionRecording.supported, false);
+    assert.equal(body.sessionRecording.canStart, false);
+    assert.equal(body.sessionRecording.canStop, false);
+    assert.equal(body.sessionRecording.active, false);
   });
+});
+
+test('session recording capability can be started and stopped through the command provider', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-recording-control-'));
+  const stateFilePath = path.join(tempDir, 'recording-state.json');
+  const recordingDir = path.join(tempDir, 'recordings');
+
+  try {
+    await withFixtureServer(async ({ baseUrl, config }) => {
+      const before = await fetch(`${baseUrl}/separation/api/capabilities/recording`);
+      assert.equal(before.status, 200);
+      assert.equal((await before.json() as { active: boolean }).active, false);
+
+      const startResponse = await fetch(`${baseUrl}/separation/api/recording/start`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'session-123', sessionDate: '2026-05-09T18:00:00.000Z', sessionStatus: 'pending' }),
+      });
+      assert.equal(startResponse.status, 200);
+      const started = await startResponse.json() as {
+        active: boolean;
+        sessionId: string | null;
+        recording: { status: string; sessionId: string | null } | null;
+      };
+      assert.equal(started.active, true);
+      assert.equal(started.sessionId, 'session-123');
+      assert.equal(started.recording?.status, 'recording');
+
+      const recordingSourcePath = path.join(recordingDir, '2026/05/09/session-123.mp4');
+      await fs.mkdir(path.dirname(recordingSourcePath), { recursive: true });
+      await fs.writeFile(recordingSourcePath, 'fake recording payload');
+
+      const stopResponse = await fetch(`${baseUrl}/separation/api/recording/stop`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'session-123', disposition: 'save' }),
+      });
+      assert.equal(stopResponse.status, 200);
+      const stopped = await stopResponse.json() as {
+        active: boolean;
+        sessionId: string | null;
+        recording: {
+          status: string;
+          sessionId: string | null;
+          relativeFilePath: string | null;
+          downloadPath: string | null;
+        } | null;
+      };
+      assert.equal(stopped.active, false);
+      assert.equal(stopped.sessionId, 'session-123');
+      assert.equal(stopped.recording?.status, 'completed');
+      assert.equal(stopped.recording?.relativeFilePath, '2026/05/09/session-123.mp4');
+      assert.equal(stopped.recording?.downloadPath, '/separation/api/recordings/file/2026/05/09/session-123.mp4');
+
+      const servedRecording = await fetch(`${baseUrl}${stopped.recording?.downloadPath}`);
+      assert.equal(servedRecording.status, 200);
+      assert.equal(await servedRecording.text(), 'fake recording payload');
+
+      const storedRecordingPath = path.join(config.recordingsDir, '2026/05/09/session-123.mp4');
+      assert.equal(await fs.readFile(storedRecordingPath, 'utf8'), 'fake recording payload');
+    }, {
+      recordingProvider: 'command',
+      recordingsDir: recordingDir,
+      recordingStatusCommand: `python3 - <<'PY'\nimport json, os\nstate_file = ${JSON.stringify(stateFilePath)}\nif not os.path.exists(state_file):\n    print(json.dumps({"active": False, "sessionId": None, "recording": None}))\nelse:\n    print(open(state_file, 'r', encoding='utf8').read())\nPY`,
+      recordingStartCommand: `python3 - <<'PY'\nimport json, os\nstate_file = ${JSON.stringify(stateFilePath)}\npayload = {"active": True, "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "recording": {"status": "recording", "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "startedAt": "2026-05-09T18:00:00.000Z", "hasAudio": True}}\nos.makedirs(os.path.dirname(state_file), exist_ok=True)\nopen(state_file, 'w', encoding='utf8').write(json.dumps(payload))\nprint(json.dumps(payload))\nPY`,
+      recordingStopCommand: `python3 - <<'PY'\nimport json, os\nstate_file = ${JSON.stringify(stateFilePath)}\npayload = {"active": False, "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "recording": {"status": "completed", "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "startedAt": "2026-05-09T18:00:00.000Z", "stoppedAt": "2026-05-09T18:12:00.000Z", "hasAudio": True, "relativeFilePath": "2026/05/09/session-123.mp4", "durationSeconds": 720, "sizeBytes": 19}}\nos.makedirs(os.path.dirname(state_file), exist_ok=True)\nopen(state_file, 'w', encoding='utf8').write(json.dumps(payload))\nprint(json.dumps(payload))\nPY`,
+    });
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test('camera streaming capability can be toggled through the command provider', async () => {

--- a/deploy/scripts/brave-paws-picam-recording-control.sh
+++ b/deploy/scripts/brave-paws-picam-recording-control.sh
@@ -134,6 +134,33 @@ is_pid_alive() {
   [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
 }
 
+terminate_recording_process() {
+  local pid="$1"
+
+  if [[ -z "$pid" ]] || ! is_pid_alive "$pid"; then
+    return 0
+  fi
+
+  kill -INT "$pid" 2>/dev/null || true
+  for _ in $(seq 1 40); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  kill -KILL "$pid" 2>/dev/null || true
+  for _ in $(seq 1 10); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.2
+  done
+
+  echo "recording process failed to stop: $pid" >&2
+  return 1
+}
+
 status_json() {
   load_state
   if [[ -n "$STATE_PID" ]] && is_pid_alive "$STATE_PID"; then
@@ -262,15 +289,12 @@ stop_recording() {
     exit 1
   fi
 
-  if [[ -n "$STATE_PID" ]] && is_pid_alive "$STATE_PID"; then
-    kill -INT "$STATE_PID" 2>/dev/null || true
-    for _ in $(seq 1 40); do
-      if ! kill -0 "$STATE_PID" 2>/dev/null; then
-        break
-      fi
-      sleep 0.5
-    done
+  if ! terminate_recording_process "$STATE_PID"; then
+    exit 1
   fi
+
+  local stopped_at
+  stopped_at="$(date -Is)"
 
   if [[ "$DISPOSITION" == 'discard' ]]; then
     rm -rf "$STATE_SESSION_DIR"
@@ -288,14 +312,14 @@ stop_recording() {
       active __FALSE__ \
       sessionId "\"$discarded_session_id\"" \
       detail __NULL__ \
-      recording "$(python3 - <<'PY' "$discarded_session_id" "$discarded_started_at" "$discarded_has_audio"
+      recording "$(python3 - <<'PY' "$discarded_session_id" "$discarded_started_at" "$stopped_at" "$discarded_has_audio"
 import json, sys
 print(json.dumps({
   'status': 'discarded',
   'sessionId': sys.argv[1] or None,
   'startedAt': sys.argv[2] or None,
-  'stoppedAt': None,
-  'hasAudio': sys.argv[3].lower() == 'true',
+  'stoppedAt': sys.argv[3] or None,
+  'hasAudio': sys.argv[4].lower() == 'true',
   'detail': None,
 }))
 PY
@@ -320,14 +344,14 @@ PY
       active __FALSE__ \
       sessionId "\"$session_id\"" \
       detail '"Recording ended before media data was written."' \
-      recording "$(python3 - <<'PY' "$session_id" "$started_at" "$has_audio"
+      recording "$(python3 - <<'PY' "$session_id" "$started_at" "$stopped_at" "$has_audio"
 import json, sys
 print(json.dumps({
   'status': 'failed',
   'sessionId': sys.argv[1] or None,
   'startedAt': sys.argv[2] or None,
-  'stoppedAt': None,
-  'hasAudio': sys.argv[3].lower() == 'true',
+  'stoppedAt': sys.argv[3] or None,
+  'hasAudio': sys.argv[4].lower() == 'true',
   'detail': 'Recording ended before media data was written.',
 }))
 PY
@@ -350,17 +374,17 @@ PY
     active __FALSE__ \
     sessionId "\"$session_id\"" \
     detail __NULL__ \
-    recording "$(python3 - <<'PY' "$session_id" "$started_at" "$has_audio" "$mp4_path" "$duration_seconds" "$size_bytes"
+    recording "$(python3 - <<'PY' "$session_id" "$started_at" "$stopped_at" "$has_audio" "$mp4_path" "$duration_seconds" "$size_bytes"
 import json, sys
 print(json.dumps({
   'status': 'completed',
   'sessionId': sys.argv[1] or None,
   'startedAt': sys.argv[2] or None,
-  'stoppedAt': None,
-  'hasAudio': sys.argv[3].lower() == 'true',
-  'remoteFilePath': sys.argv[4],
-  'durationSeconds': int(sys.argv[5]) if sys.argv[5] else None,
-  'sizeBytes': int(sys.argv[6]) if sys.argv[6] else None,
+  'stoppedAt': sys.argv[3] or None,
+  'hasAudio': sys.argv[4].lower() == 'true',
+  'remoteFilePath': sys.argv[5],
+  'durationSeconds': int(sys.argv[6]) if sys.argv[6] else None,
+  'sizeBytes': int(sys.argv[7]) if sys.argv[7] else None,
   'detail': None,
 }))
 PY

--- a/deploy/scripts/brave-paws-picam-recording-control.sh
+++ b/deploy/scripts/brave-paws-picam-recording-control.sh
@@ -1,0 +1,476 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PICAM_HOST_ALIAS="${PICAM_HOST_ALIAS:-picam}"
+PICAM_RTSP_URL="${PICAM_RTSP_URL:-rtsp://127.0.0.1:8554/live.stream}"
+REMOTE_ROOT="${BRAVE_PAWS_PICAM_RECORDING_ROOT:-/home/harvey/.cache/brave-paws/session-recording}"
+LOCAL_RECORDINGS_DIR="${BRAVE_PAWS_RECORDINGS_DIR:-${BRAVE_PAWS_DATA_DIR:-/mnt/q/fermi/brave-paws/data}/recordings}"
+
+usage() {
+  cat <<'EOF'
+Usage: brave-paws-picam-recording-control.sh <status|start|stop>
+
+This command is intended to be called by the Brave Paws backend recording provider.
+It manages a passive extra RTSP reader on `picam`, keeping the live HLS preview and
+Icecast audio path untouched.
+
+Expected environment from the Brave Paws server:
+  BRAVE_PAWS_RECORDING_SESSION_ID
+  BRAVE_PAWS_RECORDING_SESSION_DATE
+  BRAVE_PAWS_RECORDING_SESSION_STATUS
+  BRAVE_PAWS_RECORDING_DISPOSITION   save|discard
+  BRAVE_PAWS_RECORDINGS_DIR          canonical local recordings dir on QUANTUM
+
+Optional overrides:
+  PICAM_HOST_ALIAS                   SSH host alias (default: picam)
+  PICAM_RTSP_URL                     Source RTSP URL on picam (default: rtsp://127.0.0.1:8554/live.stream)
+  BRAVE_PAWS_PICAM_RECORDING_ROOT    Remote working directory on picam
+EOF
+}
+
+json_print() {
+  python3 - <<'PY' "$@"
+import json, sys
+args = sys.argv[1:]
+pairs = zip(args[0::2], args[1::2])
+out = {}
+for key, raw in pairs:
+    if raw == '__NULL__':
+        out[key] = None
+    elif raw == '__TRUE__':
+        out[key] = True
+    elif raw == '__FALSE__':
+        out[key] = False
+    else:
+        out[key] = raw
+print(json.dumps(out))
+PY
+}
+
+remote_exec() {
+  local mode="$1"
+  shift || true
+  ssh "$PICAM_HOST_ALIAS" \
+    REMOTE_ROOT="$REMOTE_ROOT" \
+    PICAM_RTSP_URL="$PICAM_RTSP_URL" \
+    BRAVE_PAWS_RECORDING_SESSION_ID="${BRAVE_PAWS_RECORDING_SESSION_ID:-}" \
+    BRAVE_PAWS_RECORDING_SESSION_DATE="${BRAVE_PAWS_RECORDING_SESSION_DATE:-}" \
+    BRAVE_PAWS_RECORDING_SESSION_STATUS="${BRAVE_PAWS_RECORDING_SESSION_STATUS:-}" \
+    BRAVE_PAWS_RECORDING_DISPOSITION="${BRAVE_PAWS_RECORDING_DISPOSITION:-save}" \
+    'bash -s' -- "$mode" <<'EOF'
+set -euo pipefail
+
+MODE="${1:-status}"
+ROOT="${REMOTE_ROOT:?}"
+SESSION_ID="${BRAVE_PAWS_RECORDING_SESSION_ID:-}"
+SESSION_DATE="${BRAVE_PAWS_RECORDING_SESSION_DATE:-}"
+SESSION_STATUS="${BRAVE_PAWS_RECORDING_SESSION_STATUS:-}"
+DISPOSITION="${BRAVE_PAWS_RECORDING_DISPOSITION:-save}"
+RTSP_URL="${PICAM_RTSP_URL:?}"
+STATE_FILE="$ROOT/state.env"
+SESSIONS_DIR="$ROOT/sessions"
+
+mkdir -p "$ROOT" "$SESSIONS_DIR"
+
+json_out() {
+  python3 - <<'PY' "$@"
+import json, sys
+args = sys.argv[1:]
+pairs = zip(args[0::2], args[1::2])
+out = {}
+for key, raw in pairs:
+    if raw == '__NULL__':
+        out[key] = None
+    elif raw == '__TRUE__':
+        out[key] = True
+    elif raw == '__FALSE__':
+        out[key] = False
+    else:
+        try:
+            out[key] = json.loads(raw)
+        except Exception:
+            out[key] = raw
+print(json.dumps(out))
+PY
+}
+
+load_state() {
+  if [[ -f "$STATE_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$STATE_FILE"
+  else
+    STATE_SESSION_ID=""
+    STATE_STARTED_AT=""
+    STATE_SESSION_DATE=""
+    STATE_PID=""
+    STATE_SESSION_DIR=""
+    STATE_MKV_PATH=""
+    STATE_MP4_PATH=""
+    STATE_LOG_PATH=""
+    STATE_HAS_AUDIO="true"
+  fi
+}
+
+write_state() {
+  cat >"$STATE_FILE" <<STATE
+STATE_SESSION_ID=${STATE_SESSION_ID@Q}
+STATE_STARTED_AT=${STATE_STARTED_AT@Q}
+STATE_SESSION_DATE=${STATE_SESSION_DATE@Q}
+STATE_PID=${STATE_PID@Q}
+STATE_SESSION_DIR=${STATE_SESSION_DIR@Q}
+STATE_MKV_PATH=${STATE_MKV_PATH@Q}
+STATE_MP4_PATH=${STATE_MP4_PATH@Q}
+STATE_LOG_PATH=${STATE_LOG_PATH@Q}
+STATE_HAS_AUDIO=${STATE_HAS_AUDIO@Q}
+STATE
+}
+
+clear_state() {
+  rm -f "$STATE_FILE"
+}
+
+is_pid_alive() {
+  local pid="$1"
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+status_json() {
+  load_state
+  if [[ -n "$STATE_PID" ]] && is_pid_alive "$STATE_PID"; then
+    json_out \
+      key '"sessionRecording"' \
+      label '"Session recording"' \
+      provider '"command"' \
+      supported __TRUE__ \
+      canStart __TRUE__ \
+      canStop __TRUE__ \
+      active __TRUE__ \
+      sessionId "\"$STATE_SESSION_ID\"" \
+      detail __NULL__ \
+      recording "$(python3 - <<'PY' "$STATE_SESSION_ID" "$STATE_STARTED_AT" "$STATE_HAS_AUDIO"
+import json, sys
+print(json.dumps({
+  'status': 'recording',
+  'sessionId': sys.argv[1],
+  'startedAt': sys.argv[2] or None,
+  'hasAudio': sys.argv[3].lower() == 'true',
+  'detail': None,
+}))
+PY
+)"
+    return
+  fi
+
+  if [[ -f "$STATE_FILE" ]]; then
+    json_out \
+      key '"sessionRecording"' \
+      label '"Session recording"' \
+      provider '"command"' \
+      supported __TRUE__ \
+      canStart __TRUE__ \
+      canStop __TRUE__ \
+      active __FALSE__ \
+      sessionId "\"$STATE_SESSION_ID\"" \
+      detail '"A previous recording process is no longer running."' \
+      recording "$(python3 - <<'PY' "$STATE_SESSION_ID" "$STATE_STARTED_AT"
+import json, sys
+print(json.dumps({
+  'status': 'failed',
+  'sessionId': sys.argv[1] or None,
+  'startedAt': sys.argv[2] or None,
+  'detail': 'A previous recording process is no longer running.',
+}))
+PY
+)"
+    return
+  fi
+
+  json_out \
+    key '"sessionRecording"' \
+    label '"Session recording"' \
+    provider '"command"' \
+    supported __TRUE__ \
+    canStart __TRUE__ \
+    canStop __TRUE__ \
+    active __FALSE__ \
+    sessionId __NULL__ \
+    detail __NULL__ \
+    recording __NULL__
+}
+
+start_recording() {
+  load_state
+
+  if [[ -z "$SESSION_ID" ]]; then
+    echo 'session id is required' >&2
+    exit 2
+  fi
+
+  if [[ -n "$STATE_PID" ]] && is_pid_alive "$STATE_PID"; then
+    if [[ "$STATE_SESSION_ID" == "$SESSION_ID" ]]; then
+      status_json
+      return
+    fi
+
+    echo "another session is already recording: $STATE_SESSION_ID" >&2
+    exit 1
+  fi
+
+  local session_dir="$SESSIONS_DIR/$SESSION_ID"
+  local mp4_path="$session_dir/final.mp4"
+  local log_path="$session_dir/ffmpeg.log"
+  mkdir -p "$session_dir"
+  rm -f "$mp4_path"
+
+  local has_audio="false"
+  if ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$RTSP_URL" 2>/dev/null | grep -q '^audio$'; then
+    has_audio="true"
+  fi
+
+  local pid
+  pid="$({ nohup ffmpeg -nostdin -hide_banner -loglevel warning -rtsp_transport tcp -i "$RTSP_URL" -map 0:v:0 -map 0:a? -c:v copy -c:a aac -b:a 96k -movflags +faststart "$mp4_path" >"$log_path" 2>&1 < /dev/null & echo $!; } )"
+  sleep 1
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo 'recording process failed to start' >&2
+    exit 1
+  fi
+
+  STATE_SESSION_ID="$SESSION_ID"
+  STATE_STARTED_AT="$(date -Is)"
+  STATE_SESSION_DATE="$SESSION_DATE"
+  STATE_PID="$pid"
+  STATE_SESSION_DIR="$session_dir"
+  STATE_MKV_PATH=""
+  STATE_MP4_PATH="$mp4_path"
+  STATE_LOG_PATH="$log_path"
+  STATE_HAS_AUDIO="$has_audio"
+  write_state
+  status_json
+}
+
+stop_recording() {
+  load_state
+
+  if [[ -z "$STATE_SESSION_ID" ]]; then
+    status_json
+    return
+  fi
+
+  if [[ -n "$SESSION_ID" && "$SESSION_ID" != "$STATE_SESSION_ID" ]]; then
+    echo "active recording belongs to a different session: $STATE_SESSION_ID" >&2
+    exit 1
+  fi
+
+  if [[ -n "$STATE_PID" ]] && is_pid_alive "$STATE_PID"; then
+    kill -INT "$STATE_PID" 2>/dev/null || true
+    for _ in $(seq 1 40); do
+      if ! kill -0 "$STATE_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.5
+    done
+  fi
+
+  if [[ "$DISPOSITION" == 'discard' ]]; then
+    rm -rf "$STATE_SESSION_DIR"
+    local discarded_session_id="$STATE_SESSION_ID"
+    local discarded_started_at="$STATE_STARTED_AT"
+    local discarded_has_audio="$STATE_HAS_AUDIO"
+    clear_state
+    json_out \
+      key '"sessionRecording"' \
+      label '"Session recording"' \
+      provider '"command"' \
+      supported __TRUE__ \
+      canStart __TRUE__ \
+      canStop __TRUE__ \
+      active __FALSE__ \
+      sessionId "\"$discarded_session_id\"" \
+      detail __NULL__ \
+      recording "$(python3 - <<'PY' "$discarded_session_id" "$discarded_started_at" "$discarded_has_audio"
+import json, sys
+print(json.dumps({
+  'status': 'discarded',
+  'sessionId': sys.argv[1] or None,
+  'startedAt': sys.argv[2] or None,
+  'stoppedAt': None,
+  'hasAudio': sys.argv[3].lower() == 'true',
+  'detail': None,
+}))
+PY
+)"
+    return
+  fi
+
+  local session_id="$STATE_SESSION_ID"
+  local started_at="$STATE_STARTED_AT"
+  local has_audio="$STATE_HAS_AUDIO"
+  local mp4_path="$STATE_MP4_PATH"
+
+  if [[ ! -s "$STATE_MP4_PATH" ]]; then
+    clear_state
+    json_out \
+      key '"sessionRecording"' \
+      label '"Session recording"' \
+      provider '"command"' \
+      supported __TRUE__ \
+      canStart __TRUE__ \
+      canStop __TRUE__ \
+      active __FALSE__ \
+      sessionId "\"$session_id\"" \
+      detail '"Recording ended before media data was written."' \
+      recording "$(python3 - <<'PY' "$session_id" "$started_at" "$has_audio"
+import json, sys
+print(json.dumps({
+  'status': 'failed',
+  'sessionId': sys.argv[1] or None,
+  'startedAt': sys.argv[2] or None,
+  'stoppedAt': None,
+  'hasAudio': sys.argv[3].lower() == 'true',
+  'detail': 'Recording ended before media data was written.',
+}))
+PY
+)"
+    return
+  fi
+
+  local duration_seconds size_bytes
+  duration_seconds="$(ffprobe -v error -show_entries format=duration -of default=nk=1:nw=1 "$STATE_MP4_PATH" | awk '{printf "%.0f", $1}' || true)"
+  size_bytes="$(stat -c '%s' "$STATE_MP4_PATH")"
+  clear_state
+
+  json_out \
+    key '"sessionRecording"' \
+    label '"Session recording"' \
+    provider '"command"' \
+    supported __TRUE__ \
+    canStart __TRUE__ \
+    canStop __TRUE__ \
+    active __FALSE__ \
+    sessionId "\"$session_id\"" \
+    detail __NULL__ \
+    recording "$(python3 - <<'PY' "$session_id" "$started_at" "$has_audio" "$mp4_path" "$duration_seconds" "$size_bytes"
+import json, sys
+print(json.dumps({
+  'status': 'completed',
+  'sessionId': sys.argv[1] or None,
+  'startedAt': sys.argv[2] or None,
+  'stoppedAt': None,
+  'hasAudio': sys.argv[3].lower() == 'true',
+  'remoteFilePath': sys.argv[4],
+  'durationSeconds': int(sys.argv[5]) if sys.argv[5] else None,
+  'sizeBytes': int(sys.argv[6]) if sys.argv[6] else None,
+  'detail': None,
+}))
+PY
+)"
+}
+
+case "$MODE" in
+  status) status_json ;;
+  start) start_recording ;;
+  stop) stop_recording ;;
+  *) echo "Unknown mode: $MODE" >&2; exit 2 ;;
+esac
+EOF
+}
+
+extract_json_field() {
+  local json="$1"
+  local field="$2"
+  python3 - <<'PY' "$json" "$field"
+import json, sys
+payload = json.loads(sys.argv[1])
+field = sys.argv[2]
+value = payload
+for part in field.split('.'):
+    if isinstance(value, dict):
+        value = value.get(part)
+    else:
+        value = None
+        break
+if value is None:
+    sys.exit(1)
+print(value)
+PY
+}
+
+status_cmd() {
+  remote_exec status
+}
+
+start_cmd() {
+  remote_exec start
+}
+
+stop_cmd() {
+  local remote_json session_id remote_file started_at relative_file destination_dir destination_path duration_seconds has_audio size_bytes recording_status
+  remote_json="$(remote_exec stop)"
+
+  if [[ "${BRAVE_PAWS_RECORDING_DISPOSITION:-save}" == 'discard' ]]; then
+    echo "$remote_json"
+    return
+  fi
+
+  recording_status="$(extract_json_field "$remote_json" 'recording.status' || true)"
+  if [[ "$recording_status" != 'completed' ]]; then
+    echo "$remote_json"
+    return
+  fi
+
+  remote_file="$(extract_json_field "$remote_json" 'recording.remoteFilePath')"
+  session_id="$(extract_json_field "$remote_json" 'recording.sessionId')"
+  started_at="$(extract_json_field "$remote_json" 'recording.startedAt' || true)"
+  duration_seconds="$(extract_json_field "$remote_json" 'recording.durationSeconds' || true)"
+  has_audio="$(extract_json_field "$remote_json" 'recording.hasAudio' || true)"
+
+  if [[ -z "$started_at" || "$started_at" == 'None' ]]; then
+    destination_dir="$LOCAL_RECORDINGS_DIR/unknown-date"
+  else
+    destination_dir="$LOCAL_RECORDINGS_DIR/$(date -d "$started_at" '+%Y/%m/%d')"
+  fi
+  mkdir -p "$destination_dir"
+  destination_path="$destination_dir/${session_id}.mp4"
+  scp -q "$PICAM_HOST_ALIAS:$remote_file" "$destination_path"
+  ssh "$PICAM_HOST_ALIAS" "rm -rf $(printf '%q' "$(dirname "$remote_file")")" >/dev/null
+
+  size_bytes="$(stat -c '%s' "$destination_path")"
+  relative_file="$(python3 - <<'PY' "$LOCAL_RECORDINGS_DIR" "$destination_path"
+import os, sys
+print(os.path.relpath(sys.argv[2], sys.argv[1]).replace(os.sep, '/'))
+PY
+)"
+
+  python3 - <<'PY' "$remote_json" "$relative_file" "$size_bytes" "$duration_seconds" "$has_audio"
+import json, sys
+payload = json.loads(sys.argv[1])
+recording = payload.get('recording') or {}
+recording['relativeFilePath'] = sys.argv[2]
+recording['sizeBytes'] = int(sys.argv[3]) if sys.argv[3] else recording.get('sizeBytes')
+if sys.argv[4]:
+    recording['durationSeconds'] = int(sys.argv[4])
+if sys.argv[5]:
+    recording['hasAudio'] = sys.argv[5].lower() == 'true'
+recording.pop('remoteFilePath', None)
+payload['recording'] = recording
+print(json.dumps(payload))
+PY
+}
+
+main() {
+  local command="${1:-}"
+  case "$command" in
+    status) status_cmd ;;
+    start) start_cmd ;;
+    stop) stop_cmd ;;
+    -h|--help|help|'') usage ;;
+    *)
+      echo "Unknown command: $command" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/deploy/systemd/brave-paws.service
+++ b/deploy/systemd/brave-paws.service
@@ -18,6 +18,11 @@ Environment="BRAVE_PAWS_CAMERA_CONTROL_LABEL=Picam streaming"
 Environment="BRAVE_PAWS_CAMERA_STATUS_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh status"
 Environment="BRAVE_PAWS_CAMERA_ENABLE_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh enable"
 Environment="BRAVE_PAWS_CAMERA_DISABLE_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh disable"
+Environment=BRAVE_PAWS_RECORDING_PROVIDER=command
+Environment="BRAVE_PAWS_RECORDING_LABEL=Session recording"
+Environment="BRAVE_PAWS_RECORDING_STATUS_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh status"
+Environment="BRAVE_PAWS_RECORDING_START_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh start"
+Environment="BRAVE_PAWS_RECORDING_STOP_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh stop"
 ExecStart=/usr/bin/env npm --prefix /mnt/q/repos/separation-tracker run server:start
 Restart=on-failure
 RestartSec=3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "separation-tracker",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "separation-tracker",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "workspaces": [
         "apps/brave-paws-landing",
         "apps/brave-paws-app",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "separation-tracker",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "workspaces": [
     "apps/brave-paws-landing",


### PR DESCRIPTION
## Summary
- add backend session-recording capability/config plumbing, start/stop endpoints, and finalized recording download serving
- add Brave Paws app recording lifecycle + status UI for active sessions, session detail, history, and stored session metadata
- add QUANTUM/picam command wiring for passive RTSP recording, update docs, and bump the patch version to v0.2.2

## Verification
- `bash -n deploy/scripts/brave-paws-picam-recording-control.sh`
- `npm test`
- `npm run lint`
- `npm run build`
- synthetic picam-stack smoke test using a temporary RTSP publisher on `picam`, with recordings written to `/tmp/brave-paws-recording-smoke/...`
  - source RTSP advertised `h264` + `aac`
  - Brave Paws recording start/stop completed successfully
  - saved MP4 verified with `ffprobe` as `h264` + `aac`
  - HLS manifest for the synthetic path stayed reachable during recording (`200`)
  - Icecast path status stayed unchanged during recording (`404` before and during because the real `rtsp-stream.service` is currently inactive on `picam`)

## Notes
- I initially tested a pure stream-copy/remux path and proved it could drop audio in the saved MP4. The final recorder keeps the passive extra-reader architecture, copies video, and explicitly encodes audio into the final MP4 instead.
- I did not restart or re-enable the real `rtsp-stream.service` on `picam` during verification, to avoid turning the live camera path back on just for testing.
