### PR TITLE
feat: add brave paws recording metadata v1

### DIFF
--- a/apps/brave-paws-app/src/components/ActiveSession.tsx
+++ b/apps/brave-paws-app/src/components/ActiveSession.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Session, SessionRecording, StepStatus } from '../types';
+import { Session, SessionRecording, SessionTimelineEvent, SessionTimelineEventType, StepStatus } from '../types';
 import { Play, Pause, CheckCircle2, Circle, Flag, X, Heart, VideoOff, RotateCcw, Minimize2, Maximize2 } from 'lucide-react';
 import { formatTime, formatDuration } from '../utils/format';
 import { buildCameraStreamUrl, isCameraUrlValid } from '../utils/cameraUrl';
@@ -62,6 +62,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
 
     return getRemainingSeconds(currentStep.durationSeconds, restoredState.stepClock);
   });
+  const [timelineEvents, setTimelineEvents] = useState<SessionTimelineEvent[]>(restoredState?.timelineEvents ?? []);
   const [previewReloadToken, setPreviewReloadToken] = useState(0);
   const [previewStatus, setPreviewStatus] = useState<'idle' | 'loading' | 'live' | 'degraded' | 'disconnected'>('idle');
   const [previewStatusMessage, setPreviewStatusMessage] = useState('Paste a stream URL, open a one-time pairing link, or use the suggested picam link to start the live preview.');
@@ -75,14 +76,18 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
   const sessionRef = useRef(session);
   const sessionClockRef = useRef(sessionClock);
   const currentStepIndexRef = useRef(currentStepIndex);
+  const isSessionRunningRef = useRef(isSessionRunning);
   const isStepRunningRef = useRef(isStepRunning);
   const stepClockRef = useRef(stepClock);
+  const timelineEventsRef = useRef(timelineEvents);
 
   sessionRef.current = session;
   sessionClockRef.current = sessionClock;
   currentStepIndexRef.current = currentStepIndex;
+  isSessionRunningRef.current = isSessionRunning;
   isStepRunningRef.current = isStepRunning;
   stepClockRef.current = stepClock;
+  timelineEventsRef.current = timelineEvents;
 
   const updateSessionClock = useCallback((clock: TimerClock) => {
     sessionClockRef.current = clock;
@@ -98,32 +103,111 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     setSessionElapsed(getElapsedSeconds(sessionClockRef.current, now));
   }, []);
 
+  const appendTimelineEvent = useCallback((
+    type: SessionTimelineEventType,
+    options: {
+      now?: number;
+      sessionRunning?: boolean;
+      currentStepIndex?: number | null;
+      stepRunning?: boolean;
+      stepStatus?: StepStatus | null;
+      sessionOverride?: Session;
+      sessionClock?: TimerClock;
+      stepClock?: TimerClock;
+    } = {},
+  ) => {
+    const now = options.now ?? Date.now();
+    const sessionSnapshot = options.sessionOverride ?? sessionRef.current;
+    const nextStepIndex = options.currentStepIndex ?? currentStepIndexRef.current;
+    const step = nextStepIndex != null ? sessionSnapshot.steps[nextStepIndex] : undefined;
+    const sessionClockSnapshot = options.sessionClock ?? sessionClockRef.current;
+    const stepClockSnapshot = options.stepClock ?? stepClockRef.current;
+    const event: SessionTimelineEvent = {
+      sequence: timelineEventsRef.current.length,
+      type,
+      occurredAt: new Date(now).toISOString(),
+      sessionElapsedSeconds: getElapsedSeconds(sessionClockSnapshot, now),
+      sessionRunning: options.sessionRunning ?? isSessionRunningRef.current,
+      currentStepIndex: nextStepIndex,
+      stepId: step?.id ?? null,
+      stepStatus: options.stepStatus ?? step?.status ?? null,
+      stepRunning: options.stepRunning ?? isStepRunningRef.current,
+      stepElapsedSeconds: step ? getElapsedSeconds(stepClockSnapshot, now) : null,
+      stepDurationSeconds: step?.durationSeconds ?? null,
+    };
+
+    const nextTimelineEvents = [...timelineEventsRef.current, event];
+    timelineEventsRef.current = nextTimelineEvents;
+    setTimelineEvents(nextTimelineEvents);
+    return event;
+  }, []);
+
+  useEffect(() => {
+    if (timelineEventsRef.current.length > 0) {
+      return;
+    }
+
+    const now = Date.now();
+    const isRestored = Boolean(restoredState);
+    appendTimelineEvent(isRestored ? 'session_resumed' : 'session_started', {
+      now,
+      sessionRunning: restoredState?.isSessionRunning ?? true,
+      currentStepIndex: restoredState?.currentStepIndex ?? 0,
+      stepRunning: restoredState?.isStepRunning ?? false,
+      sessionOverride: restoredState?.session ?? initialSession,
+      sessionClock: restoredState?.sessionClock ?? initialSessionClock,
+      stepClock: restoredState?.stepClock ?? initialStepClock,
+    });
+  }, [appendTimelineEvent, initialSession, initialSessionClock, initialStepClock, restoredState]);
+
   const finalizeStep = useCallback((index: number, status: StepStatus, now = Date.now()) => {
-    updateStepClock({ startedAt: null, accumulatedMs: 0 });
+    const pausedStepClock = pauseTimer(stepClockRef.current, now);
+    const nextStepClock = { startedAt: null, accumulatedMs: 0 };
+    const currentSession = sessionRef.current;
+    const newSteps = [...currentSession.steps];
+    newSteps[index] = { ...newSteps[index], status };
+    const updatedSession = { ...currentSession, steps: newSteps };
+
+    sessionRef.current = updatedSession;
+    setSession(updatedSession);
+    updateStepClock(nextStepClock);
     setStepRemaining(0);
     isStepRunningRef.current = false;
     setIsStepRunning(false);
 
-    setSession((prev) => {
-      const newSteps = [...prev.steps];
-      newSteps[index] = { ...newSteps[index], status };
-      const updatedSession = { ...prev, steps: newSteps };
-      sessionRef.current = updatedSession;
-      return updatedSession;
-    });
-    
-    if (index < sessionRef.current.steps.length - 1) {
+    if (index < updatedSession.steps.length - 1) {
+      appendTimelineEvent(status === 'completed' ? 'step_completed' : 'step_aborted', {
+        now,
+        currentStepIndex: index,
+        stepRunning: false,
+        stepStatus: status,
+        stepClock: pausedStepClock,
+        sessionOverride: updatedSession,
+      });
+
       const nextStepIndex = index + 1;
       currentStepIndexRef.current = nextStepIndex;
       setCurrentStepIndex(nextStepIndex);
-      setStepRemaining(sessionRef.current.steps[nextStepIndex].durationSeconds);
-    } else {
-      const pausedSessionClock = pauseTimer(sessionClockRef.current, now);
-      updateSessionClock(pausedSessionClock);
-      setSessionElapsed(getElapsedSeconds(pausedSessionClock, now));
-      setIsSessionRunning(false);
+      setStepRemaining(updatedSession.steps[nextStepIndex]!.durationSeconds);
+      return;
     }
-  }, [updateSessionClock, updateStepClock]);
+
+    const pausedSessionClock = pauseTimer(sessionClockRef.current, now);
+    updateSessionClock(pausedSessionClock);
+    setSessionElapsed(getElapsedSeconds(pausedSessionClock, now));
+    isSessionRunningRef.current = false;
+    setIsSessionRunning(false);
+    appendTimelineEvent(status === 'completed' ? 'step_completed' : 'step_aborted', {
+      now,
+      currentStepIndex: index,
+      sessionRunning: false,
+      stepRunning: false,
+      stepStatus: status,
+      sessionClock: pausedSessionClock,
+      stepClock: pausedStepClock,
+      sessionOverride: updatedSession,
+    });
+  }, [appendTimelineEvent, updateSessionClock, updateStepClock]);
 
   const syncStepRemaining = useCallback((now = Date.now()) => {
     const currentStep = sessionRef.current.steps[currentStepIndexRef.current];
@@ -169,8 +253,12 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     hasAudio: false,
     relativeFilePath: sessionRef.current.recording?.relativeFilePath ?? null,
     downloadPath: sessionRef.current.recording?.downloadPath ?? null,
+    metadataRelativeFilePath: sessionRef.current.recording?.metadataRelativeFilePath ?? null,
+    metadataDownloadPath: sessionRef.current.recording?.metadataDownloadPath ?? null,
     durationSeconds: sessionRef.current.recording?.durationSeconds ?? null,
     sizeBytes: sessionRef.current.recording?.sizeBytes ?? null,
+    chapterCount: sessionRef.current.recording?.chapterCount ?? null,
+    chaptersEmbedded: sessionRef.current.recording?.chaptersEmbedded ?? null,
     detail,
   }), [recordingCapability.provider]);
 
@@ -296,8 +384,9 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       sessionClock,
       isStepRunning,
       stepClock,
+      timelineEvents,
     });
-  }, [currentStepIndex, isSessionRunning, isStepRunning, onStateChange, session, sessionClock, stepClock]);
+  }, [currentStepIndex, isSessionRunning, isStepRunning, onStateChange, session, sessionClock, stepClock, timelineEvents]);
 
   const handleToggleSession = () => {
     const now = Date.now();
@@ -305,12 +394,25 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       const pausedClock = pauseTimer(sessionClockRef.current, now);
       updateSessionClock(pausedClock);
       setSessionElapsed(getElapsedSeconds(pausedClock, now));
+      isSessionRunningRef.current = false;
       setIsSessionRunning(false);
+      appendTimelineEvent('session_paused', {
+        now,
+        sessionRunning: false,
+        sessionClock: pausedClock,
+      });
       return;
     }
 
-    updateSessionClock(startTimer(sessionClockRef.current, now));
+    const resumedClock = startTimer(sessionClockRef.current, now);
+    updateSessionClock(resumedClock);
+    isSessionRunningRef.current = true;
     setIsSessionRunning(true);
+    appendTimelineEvent('session_resumed', {
+      now,
+      sessionRunning: true,
+      sessionClock: resumedClock,
+    });
   };
 
   const handleToggleStep = () => {
@@ -321,21 +423,52 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       setStepRemaining(
         getRemainingSeconds(sessionRef.current.steps[currentStepIndexRef.current]?.durationSeconds || 0, pausedClock, now)
       );
+      isStepRunningRef.current = false;
       setIsStepRunning(false);
+      appendTimelineEvent('step_paused', {
+        now,
+        stepRunning: false,
+        stepClock: pausedClock,
+      });
       return;
     }
 
-    updateStepClock(startTimer(stepClockRef.current, now));
+    const wasPaused = stepClockRef.current.accumulatedMs > 0;
+    const nextClock = startTimer(stepClockRef.current, now);
+    updateStepClock(nextClock);
+    isStepRunningRef.current = true;
     setIsStepRunning(true);
+    appendTimelineEvent(wasPaused ? 'step_resumed' : 'step_started', {
+      now,
+      stepRunning: true,
+      stepClock: nextClock,
+    });
   };
 
   const handleFinishSession = async () => {
     const now = Date.now();
     const finalSessionClock = isSessionRunning ? pauseTimer(sessionClockRef.current, now) : sessionClockRef.current;
+    const finalStepClock = isStepRunning ? pauseTimer(stepClockRef.current, now) : stepClockRef.current;
     updateSessionClock(finalSessionClock);
+    updateStepClock({ startedAt: null, accumulatedMs: 0 });
     setSessionElapsed(getElapsedSeconds(finalSessionClock, now));
+    isSessionRunningRef.current = false;
+    isStepRunningRef.current = false;
     setIsSessionRunning(false);
     setIsStepRunning(false);
+    appendTimelineEvent('session_finished', {
+      now,
+      sessionRunning: false,
+      stepRunning: false,
+      sessionClock: finalSessionClock,
+      stepClock: finalStepClock,
+    });
+
+    const recordingSessionSnapshot: Session = {
+      ...sessionRef.current,
+      totalDurationSeconds: getElapsedSeconds(finalSessionClock, now),
+      status: abortedSteps > 0 ? 'aborted' : 'completed',
+    };
 
     let nextRecording = sessionRef.current.recording;
     if (recordingCapability.canStop) {
@@ -344,6 +477,8 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
         const capability = await stopSessionRecording({
           sessionId: sessionRef.current.id,
           disposition: 'save',
+          sessionSnapshot: recordingSessionSnapshot,
+          timelineEvents: [...timelineEventsRef.current],
         });
         nextRecording = applyRecordingCapability(capability) ?? nextRecording;
       } catch (recordingStopError) {
@@ -358,8 +493,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     }
 
     onCompleteSession({
-      ...sessionRef.current,
-      totalDurationSeconds: getElapsedSeconds(finalSessionClock, now),
+      ...recordingSessionSnapshot,
       recording: nextRecording,
     });
   };
@@ -369,12 +503,35 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       return;
     }
 
+    const now = Date.now();
+    const finalSessionClock = isSessionRunning ? pauseTimer(sessionClockRef.current, now) : sessionClockRef.current;
+    const finalStepClock = isStepRunning ? pauseTimer(stepClockRef.current, now) : stepClockRef.current;
+    updateSessionClock(finalSessionClock);
+    updateStepClock({ startedAt: null, accumulatedMs: 0 });
+    isSessionRunningRef.current = false;
+    isStepRunningRef.current = false;
+    setIsSessionRunning(false);
+    setIsStepRunning(false);
+    appendTimelineEvent('session_cancelled', {
+      now,
+      sessionRunning: false,
+      stepRunning: false,
+      sessionClock: finalSessionClock,
+      stepClock: finalStepClock,
+    });
+
     if (recordingCapability.canStop) {
       setIsRecordingUpdating(true);
       try {
         await stopSessionRecording({
           sessionId: sessionRef.current.id,
           disposition: 'discard',
+          sessionSnapshot: {
+            ...sessionRef.current,
+            totalDurationSeconds: getElapsedSeconds(finalSessionClock, now),
+            status: 'aborted',
+          },
+          timelineEvents: [...timelineEventsRef.current],
         });
       } catch {
         // Best effort only; cancelling the session still takes priority.

--- a/apps/brave-paws-app/src/components/ActiveSession.tsx
+++ b/apps/brave-paws-app/src/components/ActiveSession.tsx
@@ -27,6 +27,18 @@ type Props = {
   onCancel: () => void;
 };
 
+export function shouldAppendInitialTimelineEvent(
+  restoredState: ActiveSessionState | undefined,
+  timelineEvents: SessionTimelineEvent[],
+) {
+  if (!restoredState) {
+    return timelineEvents.length === 0;
+  }
+
+  const lastTimelineEvent = timelineEvents[timelineEvents.length - 1];
+  return lastTimelineEvent?.type !== 'session_resumed';
+}
+
 export function ActiveSession({ session: initialSession, initialState, cameraUrl = '', onCameraUrlChange, onStateChange, onCompleteSession, onCancel }: Props) {
   const restoredState = initialState?.session.id === initialSession.id ? initialState : undefined;
   const initialSessionClock = restoredState?.sessionClock ?? {
@@ -143,7 +155,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
   }, []);
 
   useEffect(() => {
-    if (timelineEventsRef.current.length > 0) {
+    if (!shouldAppendInitialTimelineEvent(restoredState, timelineEventsRef.current)) {
       return;
     }
 

--- a/apps/brave-paws-app/src/types.ts
+++ b/apps/brave-paws-app/src/types.ts
@@ -9,6 +9,32 @@ export type Step = {
 export type SessionStatus = 'pending' | 'completed' | 'aborted';
 export type SessionRecordingStatus = 'idle' | 'recording' | 'completed' | 'discarded' | 'failed';
 
+export type SessionTimelineEventType =
+  | 'session_started'
+  | 'session_paused'
+  | 'session_resumed'
+  | 'session_finished'
+  | 'session_cancelled'
+  | 'step_started'
+  | 'step_paused'
+  | 'step_resumed'
+  | 'step_completed'
+  | 'step_aborted';
+
+export type SessionTimelineEvent = {
+  sequence: number;
+  type: SessionTimelineEventType;
+  occurredAt: string;
+  sessionElapsedSeconds: number;
+  sessionRunning: boolean;
+  currentStepIndex: number | null;
+  stepId: string | null;
+  stepStatus: StepStatus | null;
+  stepRunning: boolean;
+  stepElapsedSeconds: number | null;
+  stepDurationSeconds: number | null;
+};
+
 export type SessionRecording = {
   status: SessionRecordingStatus;
   sessionId: string | null;
@@ -18,8 +44,12 @@ export type SessionRecording = {
   hasAudio?: boolean;
   relativeFilePath?: string | null;
   downloadPath?: string | null;
+  metadataRelativeFilePath?: string | null;
+  metadataDownloadPath?: string | null;
   durationSeconds?: number | null;
   sizeBytes?: number | null;
+  chapterCount?: number | null;
+  chaptersEmbedded?: boolean | null;
   detail?: string | null;
 };
 

--- a/apps/brave-paws-app/src/utils/activeSessionStorage.ts
+++ b/apps/brave-paws-app/src/utils/activeSessionStorage.ts
@@ -1,4 +1,4 @@
-import { Session } from '../types';
+import { Session, SessionTimelineEvent, SessionTimelineEventType, StepStatus } from '../types';
 import { TimerClock } from './timer';
 import { normalizeSession } from './sessionStatus';
 
@@ -11,6 +11,7 @@ export type ActiveSessionState = {
   sessionClock: TimerClock;
   isStepRunning: boolean;
   stepClock: TimerClock;
+  timelineEvents: SessionTimelineEvent[];
 };
 
 function isTimerClock(value: unknown): value is TimerClock {
@@ -20,6 +21,65 @@ function isTimerClock(value: unknown): value is TimerClock {
 
   const candidate = value as Partial<TimerClock>;
   return (candidate.startedAt === null || typeof candidate.startedAt === 'number') && typeof candidate.accumulatedMs === 'number';
+}
+
+const TIMELINE_EVENT_TYPES = new Set<SessionTimelineEventType>([
+  'session_started',
+  'session_paused',
+  'session_resumed',
+  'session_finished',
+  'session_cancelled',
+  'step_started',
+  'step_paused',
+  'step_resumed',
+  'step_completed',
+  'step_aborted',
+]);
+
+const STEP_STATUSES = new Set<StepStatus>(['pending', 'completed', 'aborted']);
+
+function normalizeTimelineEvent(value: unknown): SessionTimelineEvent | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const occurredAt = typeof candidate.occurredAt === 'string' && Number.isFinite(Date.parse(candidate.occurredAt))
+    ? new Date(Date.parse(candidate.occurredAt)).toISOString()
+    : null;
+  const type = TIMELINE_EVENT_TYPES.has(candidate.type as SessionTimelineEventType)
+    ? (candidate.type as SessionTimelineEventType)
+    : null;
+  const sequence = typeof candidate.sequence === 'number' && Number.isFinite(candidate.sequence)
+    ? Math.max(0, Math.trunc(candidate.sequence))
+    : null;
+  const sessionElapsedSeconds = typeof candidate.sessionElapsedSeconds === 'number' && Number.isFinite(candidate.sessionElapsedSeconds)
+    ? Math.max(0, candidate.sessionElapsedSeconds)
+    : null;
+
+  if (!occurredAt || !type || sequence == null || sessionElapsedSeconds == null) {
+    return null;
+  }
+
+  return {
+    sequence,
+    type,
+    occurredAt,
+    sessionElapsedSeconds,
+    sessionRunning: typeof candidate.sessionRunning === 'boolean' ? candidate.sessionRunning : false,
+    currentStepIndex: typeof candidate.currentStepIndex === 'number' && Number.isFinite(candidate.currentStepIndex)
+      ? Math.max(0, Math.trunc(candidate.currentStepIndex))
+      : null,
+    stepId: typeof candidate.stepId === 'string' && candidate.stepId.trim() ? candidate.stepId : null,
+    stepStatus: STEP_STATUSES.has(candidate.stepStatus as StepStatus) ? (candidate.stepStatus as StepStatus) : null,
+    stepRunning: typeof candidate.stepRunning === 'boolean' ? candidate.stepRunning : false,
+    stepElapsedSeconds: typeof candidate.stepElapsedSeconds === 'number' && Number.isFinite(candidate.stepElapsedSeconds)
+      ? Math.max(0, candidate.stepElapsedSeconds)
+      : null,
+    stepDurationSeconds: typeof candidate.stepDurationSeconds === 'number' && Number.isFinite(candidate.stepDurationSeconds)
+      ? Math.max(0, candidate.stepDurationSeconds)
+      : null,
+  };
 }
 
 function normalizeActiveSessionState(value: unknown): ActiveSessionState | null {
@@ -48,6 +108,11 @@ function normalizeActiveSessionState(value: unknown): ActiveSessionState | null 
     sessionClock: candidate.sessionClock,
     isStepRunning: candidate.isStepRunning,
     stepClock: candidate.stepClock,
+    timelineEvents: Array.isArray(candidate.timelineEvents)
+      ? candidate.timelineEvents
+          .map((event) => normalizeTimelineEvent(event))
+          .filter((event): event is SessionTimelineEvent => event !== null)
+      : [],
   };
 }
 
@@ -67,6 +132,7 @@ export function createActiveSessionState(session: Session, now = Date.now()): Ac
       startedAt: null,
       accumulatedMs: 0,
     },
+    timelineEvents: [],
   };
 }
 

--- a/apps/brave-paws-app/src/utils/backendCapabilities.ts
+++ b/apps/brave-paws-app/src/utils/backendCapabilities.ts
@@ -1,5 +1,5 @@
 import { getApiBaseUrl } from '../config';
-import type { SessionRecording } from '../types';
+import type { Session, SessionRecording, SessionTimelineEvent } from '../types';
 
 export type CameraStreamingCapability = {
   key: 'cameraStreaming';
@@ -110,7 +110,12 @@ export async function startSessionRecording(
 }
 
 export async function stopSessionRecording(
-  payload: { sessionId: string; disposition?: 'save' | 'discard' },
+  payload: {
+    sessionId: string;
+    disposition?: 'save' | 'discard';
+    sessionSnapshot?: Session;
+    timelineEvents?: SessionTimelineEvent[];
+  },
   fetchImpl: typeof fetch = fetch,
   apiBaseUrl = getApiBaseUrl(),
 ): Promise<SessionRecordingCapability> {

--- a/apps/brave-paws-app/src/utils/sessionStatus.ts
+++ b/apps/brave-paws-app/src/utils/sessionStatus.ts
@@ -126,12 +126,18 @@ function normalizeSessionRecording(value: unknown, sessionId: string): SessionRe
     hasAudio: typeof candidate.hasAudio === 'boolean' ? candidate.hasAudio : false,
     relativeFilePath: typeof candidate.relativeFilePath === 'string' ? candidate.relativeFilePath : null,
     downloadPath: typeof candidate.downloadPath === 'string' ? candidate.downloadPath : null,
+    metadataRelativeFilePath: typeof candidate.metadataRelativeFilePath === 'string' ? candidate.metadataRelativeFilePath : null,
+    metadataDownloadPath: typeof candidate.metadataDownloadPath === 'string' ? candidate.metadataDownloadPath : null,
     durationSeconds: typeof candidate.durationSeconds === 'number' && Number.isFinite(candidate.durationSeconds)
       ? Math.max(0, candidate.durationSeconds)
       : null,
     sizeBytes: typeof candidate.sizeBytes === 'number' && Number.isFinite(candidate.sizeBytes)
       ? Math.max(0, candidate.sizeBytes)
       : null,
+    chapterCount: typeof candidate.chapterCount === 'number' && Number.isFinite(candidate.chapterCount)
+      ? Math.max(0, candidate.chapterCount)
+      : null,
+    chaptersEmbedded: typeof candidate.chaptersEmbedded === 'boolean' ? candidate.chaptersEmbedded : null,
     detail: typeof candidate.detail === 'string' ? candidate.detail : null,
   };
 }

--- a/apps/brave-paws-app/tests/active-session-storage.test.ts
+++ b/apps/brave-paws-app/tests/active-session-storage.test.ts
@@ -127,7 +127,7 @@ test('clearActiveSessionState removes persisted state', () => {
   assert.equal(storage.getItem(ACTIVE_SESSION_STORAGE_KEY), null);
 });
 
-test('shouldAppendInitialTimelineEvent adds a restore resume marker when prior events exist', () => {
+test('shouldAppendInitialTimelineEvent returns true when restoring sessions with prior events', () => {
   const restoredState = createActiveSessionState(createSession(), 1_000);
 
   assert.equal(shouldAppendInitialTimelineEvent(undefined, []), true);

--- a/apps/brave-paws-app/tests/active-session-storage.test.ts
+++ b/apps/brave-paws-app/tests/active-session-storage.test.ts
@@ -43,12 +43,27 @@ test('active session state roundtrips through storage', () => {
   const storage = createStorage();
   const state = createActiveSessionState(createSession(), 1_000);
 
+  const timelineEvent = {
+    sequence: 0,
+    type: 'session_started' as const,
+    occurredAt: '2026-05-10T09:00:00.000Z',
+    sessionElapsedSeconds: 0,
+    sessionRunning: true,
+    currentStepIndex: 0,
+    stepId: state.session.steps[0]!.id,
+    stepStatus: 'pending' as const,
+    stepRunning: false,
+    stepElapsedSeconds: 0,
+    stepDurationSeconds: 30,
+  };
+
   saveActiveSessionState(
     {
       ...state,
       currentStepIndex: 1,
       isStepRunning: true,
       stepClock: { startedAt: 5_000, accumulatedMs: 2_000 },
+      timelineEvents: [timelineEvent],
     },
     storage
   );
@@ -58,6 +73,7 @@ test('active session state roundtrips through storage', () => {
     currentStepIndex: 1,
     isStepRunning: true,
     stepClock: { startedAt: 5_000, accumulatedMs: 2_000 },
+    timelineEvents: [timelineEvent],
   });
 });
 
@@ -98,6 +114,7 @@ test('loadActiveSessionState normalizes legacy completion booleans', () => {
   assert.ok(restored);
   assert.equal(restored?.session.status, 'pending');
   assert.deepEqual(restored?.session.steps.map((step) => step.status), ['completed', 'pending']);
+  assert.deepEqual(restored?.timelineEvents, []);
 });
 
 test('clearActiveSessionState removes persisted state', () => {

--- a/apps/brave-paws-app/tests/active-session-storage.test.ts
+++ b/apps/brave-paws-app/tests/active-session-storage.test.ts
@@ -9,6 +9,7 @@ import {
   saveActiveSessionState,
 } from '../src/utils/activeSessionStorage.ts';
 import { Session } from '../src/types.ts';
+import { shouldAppendInitialTimelineEvent } from '../src/components/ActiveSession.tsx';
 
 function createStorage() {
   const entries = new Map<string, string>();
@@ -124,4 +125,49 @@ test('clearActiveSessionState removes persisted state', () => {
   clearActiveSessionState(storage);
 
   assert.equal(storage.getItem(ACTIVE_SESSION_STORAGE_KEY), null);
+});
+
+test('shouldAppendInitialTimelineEvent adds a restore resume marker when prior events exist', () => {
+  const restoredState = createActiveSessionState(createSession(), 1_000);
+
+  assert.equal(shouldAppendInitialTimelineEvent(undefined, []), true);
+  assert.equal(shouldAppendInitialTimelineEvent(undefined, [{
+    sequence: 0,
+    type: 'session_started',
+    occurredAt: '2026-05-10T09:00:00.000Z',
+    sessionElapsedSeconds: 0,
+    sessionRunning: true,
+    currentStepIndex: 0,
+    stepId: 'step-1',
+    stepStatus: 'pending',
+    stepRunning: false,
+    stepElapsedSeconds: 0,
+    stepDurationSeconds: 30,
+  }]), false);
+  assert.equal(shouldAppendInitialTimelineEvent(restoredState, [{
+    sequence: 0,
+    type: 'session_started',
+    occurredAt: '2026-05-10T09:00:00.000Z',
+    sessionElapsedSeconds: 0,
+    sessionRunning: true,
+    currentStepIndex: 0,
+    stepId: 'step-1',
+    stepStatus: 'pending',
+    stepRunning: false,
+    stepElapsedSeconds: 0,
+    stepDurationSeconds: 30,
+  }]), true);
+  assert.equal(shouldAppendInitialTimelineEvent(restoredState, [{
+    sequence: 1,
+    type: 'session_resumed',
+    occurredAt: '2026-05-10T09:10:00.000Z',
+    sessionElapsedSeconds: 10,
+    sessionRunning: true,
+    currentStepIndex: 0,
+    stepId: 'step-1',
+    stepStatus: 'pending',
+    stepRunning: false,
+    stepElapsedSeconds: 0,
+    stepDurationSeconds: 30,
+  }]), false);
 });

--- a/apps/brave-paws-app/tests/backend-capabilities.test.ts
+++ b/apps/brave-paws-app/tests/backend-capabilities.test.ts
@@ -135,11 +135,67 @@ test('startSessionRecording posts the session payload to the recording start end
 
 test('stopSessionRecording posts the stop payload to the recording stop endpoint', async () => {
   const capability = await stopSessionRecording(
-    { sessionId: 'session-abc', disposition: 'save' },
+    {
+      sessionId: 'session-abc',
+      disposition: 'save',
+      sessionSnapshot: {
+        id: 'session-abc',
+        date: '2026-05-09T18:00:00.000Z',
+        totalDurationSeconds: 75,
+        status: 'completed',
+        steps: [
+          { id: 'step-1', durationSeconds: 30, status: 'completed' },
+          { id: 'step-2', durationSeconds: 45, status: 'completed' },
+        ],
+      },
+      timelineEvents: [
+        {
+          sequence: 0,
+          type: 'session_started',
+          occurredAt: '2026-05-09T18:00:00.000Z',
+          sessionElapsedSeconds: 0,
+          sessionRunning: true,
+          currentStepIndex: 0,
+          stepId: 'step-1',
+          stepStatus: 'pending',
+          stepRunning: false,
+          stepElapsedSeconds: 0,
+          stepDurationSeconds: 30,
+        },
+      ],
+    },
     (async (input: string | URL | Request, init?: RequestInit) => {
       assert.equal(String(input), 'https://brave-paws.example/separation/api/recording/stop');
       assert.equal(init?.method, 'POST');
-      assert.equal(init?.body, JSON.stringify({ sessionId: 'session-abc', disposition: 'save' }));
+      assert.equal(init?.body, JSON.stringify({
+        sessionId: 'session-abc',
+        disposition: 'save',
+        sessionSnapshot: {
+          id: 'session-abc',
+          date: '2026-05-09T18:00:00.000Z',
+          totalDurationSeconds: 75,
+          status: 'completed',
+          steps: [
+            { id: 'step-1', durationSeconds: 30, status: 'completed' },
+            { id: 'step-2', durationSeconds: 45, status: 'completed' },
+          ],
+        },
+        timelineEvents: [
+          {
+            sequence: 0,
+            type: 'session_started',
+            occurredAt: '2026-05-09T18:00:00.000Z',
+            sessionElapsedSeconds: 0,
+            sessionRunning: true,
+            currentStepIndex: 0,
+            stepId: 'step-1',
+            stepStatus: 'pending',
+            stepRunning: false,
+            stepElapsedSeconds: 0,
+            stepDurationSeconds: 30,
+          },
+        ],
+      }));
 
       return new Response(JSON.stringify({
         ...UNSUPPORTED_SESSION_RECORDING_CAPABILITY,
@@ -155,6 +211,10 @@ test('stopSessionRecording posts the stop payload to the recording stop endpoint
           provider: 'command',
           relativeFilePath: '2026/05/09/session-abc.mp4',
           downloadPath: '/separation/api/recordings/file/2026/05/09/session-abc.mp4',
+          metadataRelativeFilePath: '2026/05/09/session-abc.brave-paws.json',
+          metadataDownloadPath: '/separation/api/recordings/file/2026/05/09/session-abc.brave-paws.json',
+          chapterCount: 2,
+          chaptersEmbedded: true,
         },
         detail: null,
       }), {
@@ -168,4 +228,7 @@ test('stopSessionRecording posts the stop payload to the recording stop endpoint
   assert.equal(capability.active, false);
   assert.equal(capability.recording?.status, 'completed');
   assert.equal(capability.recording?.downloadPath, '/separation/api/recordings/file/2026/05/09/session-abc.mp4');
+  assert.equal(capability.recording?.metadataDownloadPath, '/separation/api/recordings/file/2026/05/09/session-abc.brave-paws.json');
+  assert.equal(capability.recording?.chapterCount, 2);
+  assert.equal(capability.recording?.chaptersEmbedded, true);
 });

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -78,8 +78,15 @@ Brave Paws also exposes a session recording contract that is intentionally separ
 
 - `GET /separation/api/capabilities/recording` → returns recording capability and current state
 - `POST /separation/api/recording/start` with `{ "sessionId": "...", "sessionDate": "...", "sessionStatus": "..." }` → starts or resumes recording for a session
-- `POST /separation/api/recording/stop` with `{ "sessionId": "...", "disposition": "save" | "discard" }` → finalizes or discards the session recording
-- `GET /separation/api/recordings/file/<relative-path>` → streams a finalized recording file from the canonical recordings directory
+- `POST /separation/api/recording/stop` with `{ "sessionId": "...", "disposition": "save" | "discard", "sessionSnapshot": { ... }, "timelineEvents": [ ... ] }` → finalizes or discards the session recording and, on save, captures canonical Brave Paws metadata from the actual runtime timeline
+- `GET /separation/api/recordings/file/<relative-path>` → streams a finalized recording file or adjacent sidecar from the canonical recordings directory
++
++When a recording is saved successfully, Brave Paws now writes a canonical v1 JSON sidecar next to the MP4 using the same basename, for example:
++
++- `2026/05/10/session-123.mp4`
++- `2026/05/10/session-123.brave-paws.json`
++
++The JSON sidecar is the source of truth. It stores the finalized session snapshot, normalized runtime timeline events, and the derived chapter list. The backend then tries to embed those chapters into the MP4 as a VLC-friendly convenience layer. Chapter embedding is best-effort only: the recording file is kept even if FFmpeg chapter injection fails.
 
 The intended deployment model is a passive extra reader near the media source: the live RTSP publisher remains the same, the in-app HLS preview remains the same, and the Icecast audio stream remains the same. Recording should read the source RTSP feed separately and avoid inserting transcoding or buffering into the live user-facing paths.
 

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -80,13 +80,13 @@ Brave Paws also exposes a session recording contract that is intentionally separ
 - `POST /separation/api/recording/start` with `{ "sessionId": "...", "sessionDate": "...", "sessionStatus": "..." }` → starts or resumes recording for a session
 - `POST /separation/api/recording/stop` with `{ "sessionId": "...", "disposition": "save" | "discard", "sessionSnapshot": { ... }, "timelineEvents": [ ... ] }` → finalizes or discards the session recording and, on save, captures canonical Brave Paws metadata from the actual runtime timeline
 - `GET /separation/api/recordings/file/<relative-path>` → streams a finalized recording file or adjacent sidecar from the canonical recordings directory
-+
-+When a recording is saved successfully, Brave Paws now writes a canonical v1 JSON sidecar next to the MP4 using the same basename, for example:
-+
-+- `2026/05/10/session-123.mp4`
-+- `2026/05/10/session-123.brave-paws.json`
-+
-+The JSON sidecar is the source of truth. It stores the finalized session snapshot, normalized runtime timeline events, and the derived chapter list. The backend then tries to embed those chapters into the MP4 as a VLC-friendly convenience layer. Chapter embedding is best-effort only: the recording file is kept even if FFmpeg chapter injection fails.
+
+When a recording is saved successfully, Brave Paws now writes a canonical v1 JSON sidecar next to the MP4 using the same basename, for example:
+
+- `2026/05/10/session-123.mp4`
+- `2026/05/10/session-123.brave-paws.json`
+
+The JSON sidecar is the source of truth. It stores the finalized session snapshot, normalized runtime timeline events, and the derived chapter list. The backend then tries to embed those chapters into the MP4 as a VLC-friendly convenience layer. Chapter embedding is best-effort only: the recording file is kept even if FFmpeg chapter injection fails.
 
 The intended deployment model is a passive extra reader near the media source: the live RTSP publisher remains the same, the in-app HLS preview remains the same, and the Icecast audio stream remains the same. Recording should read the source RTSP feed separately and avoid inserting transcoding or buffering into the live user-facing paths.
 

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -40,6 +40,11 @@ It serves three things from one localhost process:
 | `BRAVE_PAWS_RECORDING_STATUS_COMMAND` | unset | Shell command that reports recording state as JSON or a simple `idle` / `recording` string |
 | `BRAVE_PAWS_RECORDING_START_COMMAND` | unset | Shell command that starts recording for the session id passed through Brave Paws env vars |
 | `BRAVE_PAWS_RECORDING_STOP_COMMAND` | unset | Shell command that stops/finalizes/discards recording for the session id passed through Brave Paws env vars |
+| `BRAVE_PAWS_RECORDING_VIDEO_HEIGHT` | `540` | Recording output height in pixels; width is derived to preserve aspect ratio |
+| `BRAVE_PAWS_RECORDING_VIDEO_BITRATE` | `800k` | Target H.264 video bitrate used by the picam recording helper |
+| `BRAVE_PAWS_RECORDING_VIDEO_MAXRATE` | `1000k` | H.264 VBV maxrate used by the picam recording helper |
+| `BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE` | `1600k` | H.264 VBV buffer size used by the picam recording helper |
+| `BRAVE_PAWS_RECORDING_AUDIO_BITRATE` | `96k` | AAC audio bitrate used by the picam recording helper |
 
 ## Storage
 
@@ -78,4 +83,4 @@ Brave Paws also exposes a session recording contract that is intentionally separ
 
 The intended deployment model is a passive extra reader near the media source: the live RTSP publisher remains the same, the in-app HLS preview remains the same, and the Icecast audio stream remains the same. Recording should read the source RTSP feed separately and avoid inserting transcoding or buffering into the live user-facing paths.
 
-On QUANTUM, the sample wiring for this contract lives in `deploy/scripts/brave-paws-picam-recording-control.sh`. It SSHes to `picam`, starts a passive localhost RTSP reader there, finalizes the capture, and places the canonical file under the Brave Paws recordings directory on QUANTUM after stop.
+On QUANTUM, the sample wiring for this contract lives in `deploy/scripts/brave-paws-picam-recording-control.sh`. It SSHes to `picam`, starts a passive localhost RTSP reader there, transcodes recordings to a storage-friendly H.264 MP4 profile (default: 540p at 800 kbps video plus AAC audio), finalizes the capture, and places the canonical file under the Brave Paws recordings directory on QUANTUM after stop.

--- a/apps/brave-paws-server/src/recordingControl.ts
+++ b/apps/brave-paws-server/src/recordingControl.ts
@@ -2,7 +2,8 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import type { BravePawsServerConfig } from './config.js';
-import type { SessionRecording } from './types.js';
+import { finalizeRecordingMetadata } from './recordingMetadata.js';
+import type { Session, SessionRecording, SessionTimelineEvent } from './types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -13,6 +14,8 @@ type RecordingCommandPayload = {
   sessionDate?: string;
   sessionStatus?: string;
   disposition?: 'save' | 'discard';
+  sessionSnapshot?: Session;
+  timelineEvents?: SessionTimelineEvent[];
 };
 
 export type SessionRecordingCapability = {
@@ -111,6 +114,8 @@ function normalizeRecording(value: unknown, provider: string, fallbackSessionId:
     hasAudio: typeof candidate.hasAudio === 'boolean' ? candidate.hasAudio : false,
     relativeFilePath: typeof candidate.relativeFilePath === 'string' ? candidate.relativeFilePath : null,
     downloadPath: typeof candidate.downloadPath === 'string' ? candidate.downloadPath : null,
+    metadataRelativeFilePath: typeof candidate.metadataRelativeFilePath === 'string' ? candidate.metadataRelativeFilePath : null,
+    metadataDownloadPath: typeof candidate.metadataDownloadPath === 'string' ? candidate.metadataDownloadPath : null,
     durationSeconds:
       typeof candidate.durationSeconds === 'number' && Number.isFinite(candidate.durationSeconds)
         ? Math.max(0, candidate.durationSeconds)
@@ -119,6 +124,11 @@ function normalizeRecording(value: unknown, provider: string, fallbackSessionId:
       typeof candidate.sizeBytes === 'number' && Number.isFinite(candidate.sizeBytes)
         ? Math.max(0, candidate.sizeBytes)
         : null,
+    chapterCount:
+      typeof candidate.chapterCount === 'number' && Number.isFinite(candidate.chapterCount)
+        ? Math.max(0, candidate.chapterCount)
+        : null,
+    chaptersEmbedded: typeof candidate.chaptersEmbedded === 'boolean' ? candidate.chaptersEmbedded : null,
     detail: typeof candidate.detail === 'string' ? candidate.detail : null,
   };
 }
@@ -361,7 +371,26 @@ class CommandSessionRecordingController implements SessionRecordingController {
           buildRecordingEnv(this.options.config, payload),
         );
         const capability = parseCapabilityOutput(result.stdout, this.options.label, this.options.provider);
-        return capability;
+        if (!capability.recording || payload.disposition === 'discard') {
+          return capability;
+        }
+
+        try {
+          const finalizedRecording = await finalizeRecordingMetadata({
+            config: this.options.config,
+            recording: capability.recording,
+            sessionSnapshot: payload.sessionSnapshot,
+            timelineEvents: payload.timelineEvents,
+          });
+
+          return {
+            ...capability,
+            recording: finalizedRecording,
+          };
+        } catch (metadataError) {
+          console.warn('Session recording metadata finalization failed.', metadataError);
+          return capability;
+        }
       } catch (error) {
         console.error('Session recording stop command failed', error);
         return this.readCapability(payload, getSafeCommandErrorDetail(error, getCommandFailureDetail('stop')));

--- a/apps/brave-paws-server/src/recordingMetadata.ts
+++ b/apps/brave-paws-server/src/recordingMetadata.ts
@@ -1,0 +1,466 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import type { BravePawsServerConfig } from './config.js';
+import type { Session, SessionRecording, SessionTimelineEvent, SessionTimelineEventType, StepStatus } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+const TIMELINE_EVENT_TYPES = new Set<SessionTimelineEventType>([
+  'session_started',
+  'session_paused',
+  'session_resumed',
+  'session_finished',
+  'session_cancelled',
+  'step_started',
+  'step_paused',
+  'step_resumed',
+  'step_completed',
+  'step_aborted',
+]);
+
+const STEP_STATUSES = new Set<StepStatus>(['pending', 'completed', 'aborted']);
+
+export type RecordingMetadataChapter = {
+  index: number;
+  title: string;
+  startSeconds: number;
+  endSeconds: number;
+  startTimeMs: number;
+  endTimeMs: number;
+  sourceEventSequence: number | null;
+};
+
+export type BravePawsRecordingMetadataV1 = {
+  schema: 'brave-paws-recording-metadata';
+  version: 1;
+  generatedAt: string;
+  recordingFile: {
+    relativePath: string;
+    metadataRelativePath: string;
+  };
+  session: {
+    id: string | null;
+    date: string | null;
+    status: string | null;
+    totalDurationSeconds: number | null;
+    stepCount: number;
+    steps: Array<{
+      index: number;
+      plannedDurationSeconds: number;
+      status: string;
+    }>;
+  };
+  recording: {
+    status: string;
+    provider: string;
+    sessionId: string | null;
+    startedAt: string | null;
+    stoppedAt: string | null;
+    durationSeconds: number | null;
+    hasAudio: boolean;
+    sizeBytes: number | null;
+    chapterCount: number;
+    chaptersEmbedded: boolean;
+  };
+  timeline: {
+    eventCount: number;
+    events: SessionTimelineEvent[];
+  };
+  chapters: RecordingMetadataChapter[];
+};
+
+function normalizeNonNegativeNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : null;
+}
+
+function normalizeTimestamp(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) {
+    return null;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+}
+
+function normalizeStepStatus(value: unknown): StepStatus | null {
+  return STEP_STATUSES.has(value as StepStatus) ? (value as StepStatus) : null;
+}
+
+function normalizeTimelineEvent(value: unknown): SessionTimelineEvent | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const type = TIMELINE_EVENT_TYPES.has(candidate.type as SessionTimelineEventType)
+    ? (candidate.type as SessionTimelineEventType)
+    : null;
+  const occurredAt = normalizeTimestamp(candidate.occurredAt);
+  const sequence = typeof candidate.sequence === 'number' && Number.isFinite(candidate.sequence)
+    ? Math.max(0, Math.trunc(candidate.sequence))
+    : null;
+  const sessionElapsedSeconds = normalizeNonNegativeNumber(candidate.sessionElapsedSeconds);
+
+  if (!type || occurredAt == null || sequence == null || sessionElapsedSeconds == null) {
+    return null;
+  }
+
+  return {
+    sequence,
+    type,
+    occurredAt,
+    sessionElapsedSeconds,
+    sessionRunning: typeof candidate.sessionRunning === 'boolean' ? candidate.sessionRunning : false,
+    currentStepIndex: typeof candidate.currentStepIndex === 'number' && Number.isFinite(candidate.currentStepIndex)
+      ? Math.max(0, Math.trunc(candidate.currentStepIndex))
+      : null,
+    stepId: typeof candidate.stepId === 'string' && candidate.stepId.trim() ? candidate.stepId : null,
+    stepStatus: normalizeStepStatus(candidate.stepStatus),
+    stepRunning: typeof candidate.stepRunning === 'boolean' ? candidate.stepRunning : false,
+    stepElapsedSeconds: normalizeNonNegativeNumber(candidate.stepElapsedSeconds),
+    stepDurationSeconds: normalizeNonNegativeNumber(candidate.stepDurationSeconds),
+  };
+}
+
+export function normalizeTimelineEvents(value: unknown): SessionTimelineEvent[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((event) => normalizeTimelineEvent(event))
+    .filter((event): event is SessionTimelineEvent => event !== null)
+    .sort((left, right) => {
+      const timestampDelta = Date.parse(left.occurredAt) - Date.parse(right.occurredAt);
+      if (timestampDelta !== 0) {
+        return timestampDelta;
+      }
+
+      return left.sequence - right.sequence;
+    });
+}
+
+function formatChapterDuration(durationSeconds: number | null): string | null {
+  if (durationSeconds == null) {
+    return null;
+  }
+
+  if (durationSeconds < 60) {
+    return `${durationSeconds}s`;
+  }
+
+  const minutes = Math.floor(durationSeconds / 60);
+  const seconds = durationSeconds % 60;
+  return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+function describeTimelineState(event: SessionTimelineEvent): string {
+  const stepNumber = event.currentStepIndex != null ? event.currentStepIndex + 1 : null;
+  const plannedDuration = formatChapterDuration(event.stepDurationSeconds);
+  const stepLabel = stepNumber != null
+    ? `Step ${stepNumber}${plannedDuration ? ` · ${plannedDuration}` : ''}`
+    : 'Session';
+
+  switch (event.type) {
+    case 'step_started':
+    case 'step_resumed':
+      return `${stepLabel}`;
+    case 'step_paused':
+      return `${stepLabel} paused`;
+    case 'step_completed':
+      return `${stepLabel} completed`;
+    case 'step_aborted':
+      return `${stepLabel} aborted`;
+    case 'session_paused':
+      return stepNumber != null ? `${stepLabel} · session paused` : 'Session paused';
+    case 'session_resumed':
+    case 'session_started':
+      return event.stepRunning && stepNumber != null ? stepLabel : 'Session running';
+    case 'session_finished':
+      return 'Session finished';
+    case 'session_cancelled':
+      return 'Session cancelled';
+    default:
+      return 'Session';
+  }
+}
+
+function clampMilliseconds(value: number, minValue: number, maxValue: number): number {
+  return Math.min(Math.max(value, minValue), maxValue);
+}
+
+export function deriveRecordingChapters(options: {
+  timelineEvents: SessionTimelineEvent[];
+  recordingStartedAt?: string | null;
+  recordingStoppedAt?: string | null;
+  recordingDurationSeconds?: number | null;
+}): RecordingMetadataChapter[] {
+  const timelineEvents = normalizeTimelineEvents(options.timelineEvents);
+  if (!timelineEvents.length) {
+    return [];
+  }
+
+  const firstEventMs = Date.parse(timelineEvents[0]!.occurredAt);
+  const recordingStartedAtMs = options.recordingStartedAt ? Date.parse(options.recordingStartedAt) : Number.NaN;
+  const timelineStartMs = Number.isFinite(recordingStartedAtMs) ? recordingStartedAtMs : firstEventMs;
+
+  const stoppedAtMs = options.recordingStoppedAt ? Date.parse(options.recordingStoppedAt) : Number.NaN;
+  const durationMs = options.recordingDurationSeconds != null ? Math.round(options.recordingDurationSeconds * 1000) : null;
+  const rawEndMs = Number.isFinite(stoppedAtMs)
+    ? stoppedAtMs
+    : durationMs != null
+    ? timelineStartMs + durationMs
+    : Date.parse(timelineEvents[timelineEvents.length - 1]!.occurredAt);
+  const recordingEndMs = Math.max(rawEndMs, timelineStartMs);
+
+  const chapters: RecordingMetadataChapter[] = [];
+  const appendChapter = (title: string, startTimeMs: number, endTimeMs: number, sourceEventSequence: number | null) => {
+    if (endTimeMs <= startTimeMs) {
+      return;
+    }
+
+    const previous = chapters[chapters.length - 1];
+    if (previous && previous.title === title && previous.endTimeMs === startTimeMs) {
+      previous.endTimeMs = endTimeMs;
+      previous.endSeconds = Number((endTimeMs / 1000).toFixed(3));
+      return;
+    }
+
+    chapters.push({
+      index: chapters.length + 1,
+      title,
+      startTimeMs,
+      endTimeMs,
+      startSeconds: Number((startTimeMs / 1000).toFixed(3)),
+      endSeconds: Number((endTimeMs / 1000).toFixed(3)),
+      sourceEventSequence,
+    });
+  };
+
+  const firstEventOffsetMs = clampMilliseconds(firstEventMs - timelineStartMs, 0, Math.max(recordingEndMs - timelineStartMs, 0));
+  if (firstEventOffsetMs > 0) {
+    appendChapter('Recording pre-roll', 0, firstEventOffsetMs, null);
+  }
+
+  for (let index = 0; index < timelineEvents.length; index += 1) {
+    const event = timelineEvents[index]!;
+    const nextEvent = timelineEvents[index + 1] ?? null;
+    const startTimeMs = clampMilliseconds(Date.parse(event.occurredAt) - timelineStartMs, 0, Math.max(recordingEndMs - timelineStartMs, 0));
+    const endTimeMs = nextEvent
+      ? clampMilliseconds(Date.parse(nextEvent.occurredAt) - timelineStartMs, startTimeMs, Math.max(recordingEndMs - timelineStartMs, 0))
+      : Math.max(recordingEndMs - timelineStartMs, startTimeMs);
+    appendChapter(describeTimelineState(event), startTimeMs, endTimeMs, event.sequence);
+  }
+
+  return chapters;
+}
+
+function buildMetadataRelativePath(relativeRecordingPath: string): string {
+  const dirname = path.posix.dirname(relativeRecordingPath);
+  const extension = path.posix.extname(relativeRecordingPath);
+  const basename = path.posix.basename(relativeRecordingPath, extension);
+  const metadataBasename = `${basename}.brave-paws.json`;
+  return dirname === '.' ? metadataBasename : path.posix.join(dirname, metadataBasename);
+}
+
+function buildMetadataFilePath(config: BravePawsServerConfig, relativeRecordingPath: string): string {
+  return path.join(config.recordingsDir, ...buildMetadataRelativePath(relativeRecordingPath).split('/'));
+}
+
+async function readFileSize(filePath: string): Promise<number | null> {
+  try {
+    const stats = await fs.stat(filePath);
+    return stats.isFile() ? stats.size : null;
+  } catch {
+    return null;
+  }
+}
+
+async function probeMediaDurationSeconds(filePath: string): Promise<number | null> {
+  try {
+    const { stdout } = await execFileAsync('ffprobe', [
+      '-v', 'error',
+      '-show_entries', 'format=duration',
+      '-of', 'default=noprint_wrappers=1:nokey=1',
+      filePath,
+    ], {
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024,
+    });
+    const duration = Number.parseFloat(stdout.trim());
+    return Number.isFinite(duration) ? Number(duration.toFixed(3)) : null;
+  } catch {
+    return null;
+  }
+}
+
+function escapeFfmetadataValue(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll(';', '\\;').replaceAll('#', '\\#').replaceAll('=', '\\=').replaceAll('\n', '\\n');
+}
+
+function renderFfmetadata(chapters: RecordingMetadataChapter[]): string {
+  const lines = [';FFMETADATA1'];
+
+  for (const chapter of chapters) {
+    lines.push('[CHAPTER]');
+    lines.push('TIMEBASE=1/1000');
+    lines.push(`START=${chapter.startTimeMs}`);
+    lines.push(`END=${chapter.endTimeMs}`);
+    lines.push(`title=${escapeFfmetadataValue(chapter.title)}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+async function embedChaptersIntoMp4(mp4Path: string, chapters: RecordingMetadataChapter[]): Promise<boolean> {
+  if (!chapters.length) {
+    return false;
+  }
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-mp4-chapters-'));
+  const ffmetadataPath = path.join(tempDir, 'chapters.ffmetadata');
+  const outputPath = path.join(
+    path.dirname(mp4Path),
+    `.${path.basename(mp4Path, path.extname(mp4Path))}.chapters-${process.pid}-${Date.now()}${path.extname(mp4Path)}`,
+  );
+
+  try {
+    await fs.writeFile(ffmetadataPath, renderFfmetadata(chapters), 'utf8');
+    await execFileAsync('ffmpeg', [
+      '-y',
+      '-i', mp4Path,
+      '-i', ffmetadataPath,
+      '-map', '0',
+      '-map_metadata', '1',
+      '-codec', 'copy',
+      '-movflags', '+faststart',
+      outputPath,
+    ], {
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024 * 4,
+    });
+    await fs.rename(outputPath, mp4Path);
+    return true;
+  } finally {
+    await fs.rm(outputPath, { force: true });
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+export function buildRecordingMetadataSidecar(options: {
+  sessionSnapshot?: Session | null;
+  recording: SessionRecording;
+  timelineEvents: SessionTimelineEvent[];
+  chapters: RecordingMetadataChapter[];
+  metadataRelativePath: string;
+  chaptersEmbedded: boolean;
+}): BravePawsRecordingMetadataV1 {
+  const sessionSnapshot = options.sessionSnapshot ?? null;
+
+  return {
+    schema: 'brave-paws-recording-metadata',
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    recordingFile: {
+      relativePath: options.recording.relativeFilePath ?? '',
+      metadataRelativePath: options.metadataRelativePath,
+    },
+    session: {
+      id: sessionSnapshot?.id ?? options.recording.sessionId ?? null,
+      date: sessionSnapshot?.date ?? null,
+      status: sessionSnapshot?.status ?? null,
+      totalDurationSeconds: sessionSnapshot?.totalDurationSeconds ?? null,
+      stepCount: sessionSnapshot?.steps.length ?? 0,
+      steps: (sessionSnapshot?.steps ?? []).map((step, index) => ({
+        index,
+        plannedDurationSeconds: step.durationSeconds,
+        status: step.status,
+      })),
+    },
+    recording: {
+      status: options.recording.status,
+      provider: options.recording.provider,
+      sessionId: options.recording.sessionId,
+      startedAt: options.recording.startedAt ?? null,
+      stoppedAt: options.recording.stoppedAt ?? null,
+      durationSeconds: options.recording.durationSeconds ?? null,
+      hasAudio: Boolean(options.recording.hasAudio),
+      sizeBytes: options.recording.sizeBytes ?? null,
+      chapterCount: options.chapters.length,
+      chaptersEmbedded: options.chaptersEmbedded,
+    },
+    timeline: {
+      eventCount: options.timelineEvents.length,
+      events: options.timelineEvents,
+    },
+    chapters: options.chapters,
+  };
+}
+
+export async function finalizeRecordingMetadata(options: {
+  config: BravePawsServerConfig;
+  recording: SessionRecording;
+  sessionSnapshot?: Session | null;
+  timelineEvents?: SessionTimelineEvent[];
+}): Promise<SessionRecording> {
+  const { recording } = options;
+  if (recording.status !== 'completed' || !recording.relativeFilePath) {
+    return recording;
+  }
+
+  const resolvedRecordingPath = path.join(options.config.recordingsDir, ...recording.relativeFilePath.split('/'));
+  const normalizedTimelineEvents = normalizeTimelineEvents(options.timelineEvents);
+  const measuredSizeBytes = recording.sizeBytes ?? await readFileSize(resolvedRecordingPath);
+  const measuredDurationSeconds = recording.durationSeconds ?? await probeMediaDurationSeconds(resolvedRecordingPath);
+  const metadataRelativePath = buildMetadataRelativePath(recording.relativeFilePath);
+  const metadataFilePath = buildMetadataFilePath(options.config, recording.relativeFilePath);
+  const nextRecording: SessionRecording = {
+    ...recording,
+    sizeBytes: measuredSizeBytes,
+    durationSeconds: measuredDurationSeconds,
+    metadataRelativeFilePath: metadataRelativePath,
+  };
+
+  const chapters = deriveRecordingChapters({
+    timelineEvents: normalizedTimelineEvents,
+    recordingStartedAt: nextRecording.startedAt,
+    recordingStoppedAt: nextRecording.stoppedAt,
+    recordingDurationSeconds: nextRecording.durationSeconds,
+  });
+
+  let chaptersEmbedded = false;
+  if (path.extname(resolvedRecordingPath).toLowerCase() === '.mp4') {
+    try {
+      chaptersEmbedded = await embedChaptersIntoMp4(resolvedRecordingPath, chapters);
+    } catch (error) {
+      console.warn('Unable to embed Brave Paws MP4 chapters.', error);
+    }
+  }
+
+  const sidecar = buildRecordingMetadataSidecar({
+    sessionSnapshot: options.sessionSnapshot,
+    recording: {
+      ...nextRecording,
+      chapterCount: chapters.length,
+      chaptersEmbedded,
+    },
+    timelineEvents: normalizedTimelineEvents,
+    chapters,
+    metadataRelativePath,
+    chaptersEmbedded,
+  });
+
+  await fs.mkdir(path.dirname(metadataFilePath), { recursive: true });
+  await fs.writeFile(metadataFilePath, `${JSON.stringify(sidecar, null, 2)}\n`, 'utf8');
+
+  return {
+    ...nextRecording,
+    chapterCount: chapters.length,
+    chaptersEmbedded,
+  };
+}

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -638,7 +638,7 @@ async function handleApiRequest(
       }>(request, { maxBytes: RECORDING_STOP_REQUEST_MAX_BYTES });
     } catch (error) {
       if (error instanceof JsonBodyTooLargeError) {
-        sendJson(response, 413, { error: 'Recording stop payload is too large' });
+        sendJson(response, 413, { error: 'Recording stop payload exceeds maximum size of 512KB' });
         return;
       }
       throw error;

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -15,6 +15,7 @@ import {
   type SessionRecordingCapability,
   type SessionRecordingController,
 } from './recordingControl.js';
+import { normalizeTimelineEvents } from './recordingMetadata.js';
 import {
   buildPairingAppUrl,
   consumePairing,
@@ -453,7 +454,7 @@ function buildRecordingDownloadPath(apiBasePath: string, relativeFilePath: strin
 }
 
 function attachRecordingDownloadPath(apiBasePath: string, capability: SessionRecordingCapability): SessionRecordingCapability {
-  if (!capability.recording?.relativeFilePath) {
+  if (!capability.recording) {
     return capability;
   }
 
@@ -462,6 +463,7 @@ function attachRecordingDownloadPath(apiBasePath: string, capability: SessionRec
     recording: {
       ...capability.recording,
       downloadPath: buildRecordingDownloadPath(apiBasePath, capability.recording.relativeFilePath),
+      metadataDownloadPath: buildRecordingDownloadPath(apiBasePath, capability.recording.metadataRelativeFilePath),
     },
   };
 }
@@ -605,13 +607,21 @@ async function handleApiRequest(
       return;
     }
 
-    const payload = await readJsonBody<{ sessionId?: string; disposition?: 'save' | 'discard' }>(request);
+    const payload = await readJsonBody<{
+      sessionId?: string;
+      disposition?: 'save' | 'discard';
+      sessionSnapshot?: Session;
+      timelineEvents?: unknown[];
+    }>(request);
     if (!payload.sessionId) {
       sendJson(response, 400, { error: 'sessionId is required' });
       return;
     }
 
-    sendJson(response, 200, attachRecordingDownloadPath(config.apiBasePath, await sessionRecordingController.stopRecording(payload)));
+    sendJson(response, 200, attachRecordingDownloadPath(config.apiBasePath, await sessionRecordingController.stopRecording({
+      ...payload,
+      timelineEvents: normalizeTimelineEvents(payload.timelineEvents),
+    })));
     return;
   }
 

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -35,6 +35,15 @@ const JSON_HEADERS = {
   'cache-control': 'no-store',
 };
 
+const RECORDING_STOP_REQUEST_MAX_BYTES = 512 * 1024;
+
+class JsonBodyTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`JSON request body exceeds ${maxBytes} bytes`);
+    this.name = 'JsonBodyTooLargeError';
+  }
+}
+
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown) {
   response.writeHead(statusCode, JSON_HEADERS);
   response.end(`${JSON.stringify(payload, null, 2)}\n`);
@@ -112,11 +121,17 @@ function sanitizeClientDiagnosticPayload(payload: unknown, request: IncomingMess
   };
 }
 
-async function readJsonBody<T>(request: IncomingMessage): Promise<T> {
+async function readJsonBody<T>(request: IncomingMessage, options: { maxBytes?: number } = {}): Promise<T> {
   const chunks: Buffer[] = [];
+  let totalBytes = 0;
 
   for await (const chunk of request) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.length;
+    if (options.maxBytes != null && totalBytes > options.maxBytes) {
+      throw new JsonBodyTooLargeError(options.maxBytes);
+    }
+    chunks.push(buffer);
   }
 
   const raw = Buffer.concat(chunks).toString('utf8').trim();
@@ -607,12 +622,28 @@ async function handleApiRequest(
       return;
     }
 
-    const payload = await readJsonBody<{
+    let payload: {
       sessionId?: string;
       disposition?: 'save' | 'discard';
       sessionSnapshot?: Session;
       timelineEvents?: unknown[];
-    }>(request);
+    };
+
+    try {
+      payload = await readJsonBody<{
+        sessionId?: string;
+        disposition?: 'save' | 'discard';
+        sessionSnapshot?: Session;
+        timelineEvents?: unknown[];
+      }>(request, { maxBytes: RECORDING_STOP_REQUEST_MAX_BYTES });
+    } catch (error) {
+      if (error instanceof JsonBodyTooLargeError) {
+        sendJson(response, 413, { error: 'Recording stop payload is too large' });
+        return;
+      }
+      throw error;
+    }
+
     if (!payload.sessionId) {
       sendJson(response, 400, { error: 'sessionId is required' });
       return;

--- a/apps/brave-paws-server/src/types.ts
+++ b/apps/brave-paws-server/src/types.ts
@@ -9,6 +9,32 @@ export type Step = {
 export type SessionStatus = 'pending' | 'completed' | 'aborted';
 export type SessionRecordingStatus = 'idle' | 'recording' | 'completed' | 'discarded' | 'failed';
 
+export type SessionTimelineEventType =
+  | 'session_started'
+  | 'session_paused'
+  | 'session_resumed'
+  | 'session_finished'
+  | 'session_cancelled'
+  | 'step_started'
+  | 'step_paused'
+  | 'step_resumed'
+  | 'step_completed'
+  | 'step_aborted';
+
+export type SessionTimelineEvent = {
+  sequence: number;
+  type: SessionTimelineEventType;
+  occurredAt: string;
+  sessionElapsedSeconds: number;
+  sessionRunning: boolean;
+  currentStepIndex: number | null;
+  stepId: string | null;
+  stepStatus: StepStatus | null;
+  stepRunning: boolean;
+  stepElapsedSeconds: number | null;
+  stepDurationSeconds: number | null;
+};
+
 export type SessionRecording = {
   status: SessionRecordingStatus;
   sessionId: string | null;
@@ -18,8 +44,12 @@ export type SessionRecording = {
   hasAudio?: boolean;
   relativeFilePath?: string | null;
   downloadPath?: string | null;
+  metadataRelativeFilePath?: string | null;
+  metadataDownloadPath?: string | null;
   durationSeconds?: number | null;
   sizeBytes?: number | null;
+  chapterCount?: number | null;
+  chaptersEmbedded?: boolean | null;
   detail?: string | null;
 };
 

--- a/apps/brave-paws-server/tests/recordingMetadata.test.ts
+++ b/apps/brave-paws-server/tests/recordingMetadata.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildRecordingMetadataSidecar,
+  deriveRecordingChapters,
+  normalizeTimelineEvents,
+} from '../src/recordingMetadata.ts';
+import type { Session, SessionRecording, SessionTimelineEvent } from '../src/types.ts';
+
+test('deriveRecordingChapters uses actual runtime event timing instead of naive planned duration sums', () => {
+  const timelineEvents: SessionTimelineEvent[] = normalizeTimelineEvents([
+    {
+      sequence: 0,
+      type: 'session_started',
+      occurredAt: '2026-05-10T09:00:00.000Z',
+      sessionElapsedSeconds: 0,
+      sessionRunning: true,
+      currentStepIndex: 0,
+      stepId: 'step-1',
+      stepStatus: 'pending',
+      stepRunning: false,
+      stepElapsedSeconds: 0,
+      stepDurationSeconds: 30,
+    },
+    {
+      sequence: 1,
+      type: 'step_started',
+      occurredAt: '2026-05-10T09:00:00.000Z',
+      sessionElapsedSeconds: 0,
+      sessionRunning: true,
+      currentStepIndex: 0,
+      stepId: 'step-1',
+      stepStatus: 'pending',
+      stepRunning: true,
+      stepElapsedSeconds: 0,
+      stepDurationSeconds: 30,
+    },
+    {
+      sequence: 2,
+      type: 'step_completed',
+      occurredAt: '2026-05-10T09:00:30.000Z',
+      sessionElapsedSeconds: 30,
+      sessionRunning: true,
+      currentStepIndex: 0,
+      stepId: 'step-1',
+      stepStatus: 'completed',
+      stepRunning: false,
+      stepElapsedSeconds: 30,
+      stepDurationSeconds: 30,
+    },
+    {
+      sequence: 3,
+      type: 'step_started',
+      occurredAt: '2026-05-10T09:00:45.000Z',
+      sessionElapsedSeconds: 45,
+      sessionRunning: true,
+      currentStepIndex: 1,
+      stepId: 'step-2',
+      stepStatus: 'pending',
+      stepRunning: true,
+      stepElapsedSeconds: 0,
+      stepDurationSeconds: 20,
+    },
+    {
+      sequence: 4,
+      type: 'session_finished',
+      occurredAt: '2026-05-10T09:01:00.000Z',
+      sessionElapsedSeconds: 60,
+      sessionRunning: false,
+      currentStepIndex: 1,
+      stepId: 'step-2',
+      stepStatus: 'completed',
+      stepRunning: false,
+      stepElapsedSeconds: 15,
+      stepDurationSeconds: 20,
+    },
+  ]);
+
+  const chapters = deriveRecordingChapters({
+    timelineEvents,
+    recordingStartedAt: '2026-05-10T09:00:00.000Z',
+    recordingStoppedAt: '2026-05-10T09:01:00.000Z',
+  });
+
+  assert.deepEqual(chapters.map((chapter) => ({ title: chapter.title, startSeconds: chapter.startSeconds, endSeconds: chapter.endSeconds })), [
+    { title: 'Step 1 · 30s', startSeconds: 0, endSeconds: 30 },
+    { title: 'Step 1 · 30s completed', startSeconds: 30, endSeconds: 45 },
+    { title: 'Step 2 · 20s', startSeconds: 45, endSeconds: 60 },
+  ]);
+});
+
+test('buildRecordingMetadataSidecar emits the canonical v1 sidecar structure', () => {
+  const sessionSnapshot: Session = {
+    id: 'session-123',
+    date: '2026-05-10T09:00:00.000Z',
+    totalDurationSeconds: 60,
+    status: 'completed',
+    steps: [
+      { id: 'step-1', durationSeconds: 30, status: 'completed' },
+      { id: 'step-2', durationSeconds: 20, status: 'completed' },
+    ],
+  };
+  const recording: SessionRecording = {
+    status: 'completed',
+    sessionId: 'session-123',
+    provider: 'command',
+    startedAt: '2026-05-10T09:00:00.000Z',
+    stoppedAt: '2026-05-10T09:01:00.000Z',
+    relativeFilePath: '2026/05/10/session-123.mp4',
+    metadataRelativeFilePath: '2026/05/10/session-123.brave-paws.json',
+    durationSeconds: 60,
+    sizeBytes: 1024,
+    chapterCount: 3,
+    chaptersEmbedded: true,
+    hasAudio: true,
+  };
+  const timelineEvents = normalizeTimelineEvents([
+    {
+      sequence: 0,
+      type: 'step_started',
+      occurredAt: '2026-05-10T09:00:00.000Z',
+      sessionElapsedSeconds: 0,
+      sessionRunning: true,
+      currentStepIndex: 0,
+      stepId: 'step-1',
+      stepStatus: 'pending',
+      stepRunning: true,
+      stepElapsedSeconds: 0,
+      stepDurationSeconds: 30,
+    },
+  ]);
+  const chapters = deriveRecordingChapters({
+    timelineEvents,
+    recordingStartedAt: '2026-05-10T09:00:00.000Z',
+    recordingStoppedAt: '2026-05-10T09:01:00.000Z',
+  });
+
+  const sidecar = buildRecordingMetadataSidecar({
+    sessionSnapshot,
+    recording,
+    timelineEvents,
+    chapters,
+    metadataRelativePath: '2026/05/10/session-123.brave-paws.json',
+    chaptersEmbedded: true,
+  });
+
+  assert.equal(sidecar.schema, 'brave-paws-recording-metadata');
+  assert.equal(sidecar.version, 1);
+  assert.equal(sidecar.recordingFile.relativePath, '2026/05/10/session-123.mp4');
+  assert.equal(sidecar.recordingFile.metadataRelativePath, '2026/05/10/session-123.brave-paws.json');
+  assert.equal(sidecar.session.stepCount, 2);
+  assert.equal(sidecar.recording.chapterCount, chapters.length);
+  assert.equal(sidecar.recording.chaptersEmbedded, true);
+  assert.equal(sidecar.timeline.eventCount, 1);
+});

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -344,7 +344,7 @@ test('recording stop rejects oversized JSON payloads', async () => {
     });
 
     assert.equal(response.status, 413);
-    assert.match(await response.text(), /too large/i);
+    assert.match(await response.text(), /maximum size of 512KB/i);
   });
 });
 

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -316,6 +316,38 @@ test('recording download rejects malformed path segments instead of crashing', a
   });
 });
 
+test('recording stop rejects oversized JSON payloads', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const oversizedTimelineEvent = {
+      sequence: 0,
+      type: 'session_started',
+      occurredAt: '2026-05-09T18:00:00.000Z',
+      sessionElapsedSeconds: 0,
+      sessionRunning: true,
+      currentStepIndex: 0,
+      stepId: 'step-1',
+      stepStatus: 'pending',
+      stepRunning: false,
+      stepElapsedSeconds: 0,
+      stepDurationSeconds: 30,
+      note: 'x'.repeat(600_000),
+    };
+
+    const response = await fetch(`${baseUrl}/separation/api/recording/stop`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        sessionId: 'session-123',
+        disposition: 'discard',
+        timelineEvents: [oversizedTimelineEvent],
+      }),
+    });
+
+    assert.equal(response.status, 413);
+    assert.match(await response.text(), /too large/i);
+  });
+});
+
 test('recording download requires auth when an auth token is configured', async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-recording-auth-'));
   const recordingDir = path.join(tempDir, 'recordings');

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -180,7 +180,74 @@ test('session recording capability can be started and stopped through the comman
       const stopResponse = await fetch(`${baseUrl}/separation/api/recording/stop`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ sessionId: 'session-123', disposition: 'save' }),
+        body: JSON.stringify({
+          sessionId: 'session-123',
+          disposition: 'save',
+          sessionSnapshot: {
+            id: 'session-123',
+            date: '2026-05-09T18:00:00.000Z',
+            totalDurationSeconds: 720,
+            status: 'completed',
+            steps: [
+              { id: 'step-1', durationSeconds: 30, status: 'completed' },
+              { id: 'step-2', durationSeconds: 690, status: 'completed' },
+            ],
+          },
+          timelineEvents: [
+            {
+              sequence: 0,
+              type: 'session_started',
+              occurredAt: '2026-05-09T18:00:00.000Z',
+              sessionElapsedSeconds: 0,
+              sessionRunning: true,
+              currentStepIndex: 0,
+              stepId: 'step-1',
+              stepStatus: 'pending',
+              stepRunning: false,
+              stepElapsedSeconds: 0,
+              stepDurationSeconds: 30,
+            },
+            {
+              sequence: 1,
+              type: 'step_started',
+              occurredAt: '2026-05-09T18:00:00.000Z',
+              sessionElapsedSeconds: 0,
+              sessionRunning: true,
+              currentStepIndex: 0,
+              stepId: 'step-1',
+              stepStatus: 'pending',
+              stepRunning: true,
+              stepElapsedSeconds: 0,
+              stepDurationSeconds: 30,
+            },
+            {
+              sequence: 2,
+              type: 'step_completed',
+              occurredAt: '2026-05-09T18:00:30.000Z',
+              sessionElapsedSeconds: 30,
+              sessionRunning: true,
+              currentStepIndex: 0,
+              stepId: 'step-1',
+              stepStatus: 'completed',
+              stepRunning: false,
+              stepElapsedSeconds: 30,
+              stepDurationSeconds: 30,
+            },
+            {
+              sequence: 3,
+              type: 'session_finished',
+              occurredAt: '2026-05-09T18:12:00.000Z',
+              sessionElapsedSeconds: 720,
+              sessionRunning: false,
+              currentStepIndex: 1,
+              stepId: 'step-2',
+              stepStatus: 'completed',
+              stepRunning: false,
+              stepElapsedSeconds: 690,
+              stepDurationSeconds: 690,
+            },
+          ],
+        }),
       });
       assert.equal(stopResponse.status, 200);
       const stopped = await stopResponse.json() as {
@@ -191,6 +258,10 @@ test('session recording capability can be started and stopped through the comman
           sessionId: string | null;
           relativeFilePath: string | null;
           downloadPath: string | null;
+          metadataRelativeFilePath: string | null;
+          metadataDownloadPath: string | null;
+          chapterCount: number | null;
+          chaptersEmbedded: boolean | null;
         } | null;
       };
       assert.equal(stopped.active, false);
@@ -198,6 +269,10 @@ test('session recording capability can be started and stopped through the comman
       assert.equal(stopped.recording?.status, 'completed');
       assert.equal(stopped.recording?.relativeFilePath, '2026/05/09/session-123.mp4');
       assert.equal(stopped.recording?.downloadPath, '/separation/api/recordings/file/2026/05/09/session-123.mp4');
+      assert.equal(stopped.recording?.metadataRelativeFilePath, '2026/05/09/session-123.brave-paws.json');
+      assert.equal(stopped.recording?.metadataDownloadPath, '/separation/api/recordings/file/2026/05/09/session-123.brave-paws.json');
+      assert.equal(stopped.recording?.chapterCount, 2);
+      assert.equal(stopped.recording?.chaptersEmbedded, false);
 
       const servedRecording = await fetch(`${baseUrl}${stopped.recording?.downloadPath}`);
       assert.equal(servedRecording.status, 200);
@@ -205,6 +280,22 @@ test('session recording capability can be started and stopped through the comman
 
       const storedRecordingPath = path.join(config.recordingsDir, '2026/05/09/session-123.mp4');
       assert.equal(await fs.readFile(storedRecordingPath, 'utf8'), 'fake recording payload');
+
+      const storedMetadataPath = path.join(config.recordingsDir, '2026/05/09/session-123.brave-paws.json');
+      const sidecar = JSON.parse(await fs.readFile(storedMetadataPath, 'utf8')) as {
+        version: number;
+        recordingFile: { metadataRelativePath: string; relativePath: string };
+        recording: { chapterCount: number; chaptersEmbedded: boolean };
+        timeline: { eventCount: number };
+        chapters: Array<{ title: string }>;
+      };
+      assert.equal(sidecar.version, 1);
+      assert.equal(sidecar.recordingFile.relativePath, '2026/05/09/session-123.mp4');
+      assert.equal(sidecar.recordingFile.metadataRelativePath, '2026/05/09/session-123.brave-paws.json');
+      assert.equal(sidecar.recording.chapterCount, 2);
+      assert.equal(sidecar.recording.chaptersEmbedded, false);
+      assert.equal(sidecar.timeline.eventCount, 4);
+      assert.deepEqual(sidecar.chapters.map((chapter) => chapter.title), ['Step 1 · 30s', 'Step 1 · 30s completed']);
     }, {
       recordingProvider: 'command',
       recordingsDir: recordingDir,

--- a/deploy/scripts/brave-paws-picam-recording-control.sh
+++ b/deploy/scripts/brave-paws-picam-recording-control.sh
@@ -5,6 +5,11 @@ PICAM_HOST_ALIAS="${PICAM_HOST_ALIAS:-picam}"
 PICAM_RTSP_URL="${PICAM_RTSP_URL:-rtsp://127.0.0.1:8554/live.stream}"
 REMOTE_ROOT="${BRAVE_PAWS_PICAM_RECORDING_ROOT:-/home/harvey/.cache/brave-paws/session-recording}"
 LOCAL_RECORDINGS_DIR="${BRAVE_PAWS_RECORDINGS_DIR:-${BRAVE_PAWS_DATA_DIR:-/mnt/q/fermi/brave-paws/data}/recordings}"
+RECORDING_VIDEO_HEIGHT="${BRAVE_PAWS_RECORDING_VIDEO_HEIGHT:-540}"
+RECORDING_VIDEO_BITRATE="${BRAVE_PAWS_RECORDING_VIDEO_BITRATE:-800k}"
+RECORDING_VIDEO_MAXRATE="${BRAVE_PAWS_RECORDING_VIDEO_MAXRATE:-1000k}"
+RECORDING_VIDEO_BUFSIZE="${BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE:-1600k}"
+RECORDING_AUDIO_BITRATE="${BRAVE_PAWS_RECORDING_AUDIO_BITRATE:-96k}"
 
 usage() {
   cat <<'EOF'
@@ -25,6 +30,11 @@ Optional overrides:
   PICAM_HOST_ALIAS                   SSH host alias (default: picam)
   PICAM_RTSP_URL                     Source RTSP URL on picam (default: rtsp://127.0.0.1:8554/live.stream)
   BRAVE_PAWS_PICAM_RECORDING_ROOT    Remote working directory on picam
+  BRAVE_PAWS_RECORDING_VIDEO_HEIGHT  Output height in px, preserving aspect ratio (default: 540)
+  BRAVE_PAWS_RECORDING_VIDEO_BITRATE Target video bitrate (default: 800k)
+  BRAVE_PAWS_RECORDING_VIDEO_MAXRATE Video VBV maxrate (default: 1000k)
+  BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE Video VBV bufsize (default: 1600k)
+  BRAVE_PAWS_RECORDING_AUDIO_BITRATE AAC audio bitrate (default: 96k)
 EOF
 }
 
@@ -57,6 +67,11 @@ remote_exec() {
     BRAVE_PAWS_RECORDING_SESSION_DATE="${BRAVE_PAWS_RECORDING_SESSION_DATE:-}" \
     BRAVE_PAWS_RECORDING_SESSION_STATUS="${BRAVE_PAWS_RECORDING_SESSION_STATUS:-}" \
     BRAVE_PAWS_RECORDING_DISPOSITION="${BRAVE_PAWS_RECORDING_DISPOSITION:-save}" \
+    BRAVE_PAWS_RECORDING_VIDEO_HEIGHT="$RECORDING_VIDEO_HEIGHT" \
+    BRAVE_PAWS_RECORDING_VIDEO_BITRATE="$RECORDING_VIDEO_BITRATE" \
+    BRAVE_PAWS_RECORDING_VIDEO_MAXRATE="$RECORDING_VIDEO_MAXRATE" \
+    BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE="$RECORDING_VIDEO_BUFSIZE" \
+    BRAVE_PAWS_RECORDING_AUDIO_BITRATE="$RECORDING_AUDIO_BITRATE" \
     'bash -s' -- "$mode" <<'EOF'
 set -euo pipefail
 
@@ -67,6 +82,11 @@ SESSION_DATE="${BRAVE_PAWS_RECORDING_SESSION_DATE:-}"
 SESSION_STATUS="${BRAVE_PAWS_RECORDING_SESSION_STATUS:-}"
 DISPOSITION="${BRAVE_PAWS_RECORDING_DISPOSITION:-save}"
 RTSP_URL="${PICAM_RTSP_URL:?}"
+VIDEO_HEIGHT="${BRAVE_PAWS_RECORDING_VIDEO_HEIGHT:-540}"
+VIDEO_BITRATE="${BRAVE_PAWS_RECORDING_VIDEO_BITRATE:-800k}"
+VIDEO_MAXRATE="${BRAVE_PAWS_RECORDING_VIDEO_MAXRATE:-1000k}"
+VIDEO_BUFSIZE="${BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE:-1600k}"
+AUDIO_BITRATE="${BRAVE_PAWS_RECORDING_AUDIO_BITRATE:-96k}"
 STATE_FILE="$ROOT/state.env"
 SESSIONS_DIR="$ROOT/sessions"
 
@@ -254,8 +274,11 @@ start_recording() {
     has_audio="true"
   fi
 
+  local scale_filter
+  scale_filter="scale=-2:${VIDEO_HEIGHT}:flags=lanczos"
+
   local pid
-  pid="$({ nohup ffmpeg -nostdin -hide_banner -loglevel warning -rtsp_transport tcp -i "$RTSP_URL" -map 0:v:0 -map 0:a? -c:v copy -c:a aac -b:a 96k -movflags +faststart "$mp4_path" >"$log_path" 2>&1 < /dev/null & echo $!; } )"
+  pid="$({ nohup ffmpeg -nostdin -hide_banner -loglevel warning -rtsp_transport tcp -i "$RTSP_URL" -map 0:v:0 -map 0:a? -vf "$scale_filter" -c:v libx264 -preset veryfast -pix_fmt yuv420p -b:v "$VIDEO_BITRATE" -maxrate "$VIDEO_MAXRATE" -bufsize "$VIDEO_BUFSIZE" -c:a aac -b:a "$AUDIO_BITRATE" -movflags +faststart "$mp4_path" >"$log_path" 2>&1 < /dev/null & echo $!; } )"
   sleep 1
 
   if ! kill -0 "$pid" 2>/dev/null; then

--- a/deploy/systemd/brave-paws.service
+++ b/deploy/systemd/brave-paws.service
@@ -23,11 +23,11 @@ Environment="BRAVE_PAWS_RECORDING_LABEL=Session recording"
 Environment="BRAVE_PAWS_RECORDING_STATUS_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh status"
 Environment="BRAVE_PAWS_RECORDING_START_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh start"
 Environment="BRAVE_PAWS_RECORDING_STOP_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh stop"
-Environment=BRAVE_PAWS_RECORDING_VIDEO_HEIGHT=540
-Environment=BRAVE_PAWS_RECORDING_VIDEO_BITRATE=800k
-Environment=BRAVE_PAWS_RECORDING_VIDEO_MAXRATE=1000k
-Environment=BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE=1600k
-Environment=BRAVE_PAWS_RECORDING_AUDIO_BITRATE=96k
+Environment="BRAVE_PAWS_RECORDING_VIDEO_HEIGHT=540"
+Environment="BRAVE_PAWS_RECORDING_VIDEO_BITRATE=800k"
+Environment="BRAVE_PAWS_RECORDING_VIDEO_MAXRATE=1000k"
+Environment="BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE=1600k"
+Environment="BRAVE_PAWS_RECORDING_AUDIO_BITRATE=96k"
 ExecStart=/usr/bin/env npm --prefix /mnt/q/repos/separation-tracker run server:start
 Restart=on-failure
 RestartSec=3

--- a/deploy/systemd/brave-paws.service
+++ b/deploy/systemd/brave-paws.service
@@ -23,6 +23,11 @@ Environment="BRAVE_PAWS_RECORDING_LABEL=Session recording"
 Environment="BRAVE_PAWS_RECORDING_STATUS_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh status"
 Environment="BRAVE_PAWS_RECORDING_START_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh start"
 Environment="BRAVE_PAWS_RECORDING_STOP_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh stop"
+Environment=BRAVE_PAWS_RECORDING_VIDEO_HEIGHT=540
+Environment=BRAVE_PAWS_RECORDING_VIDEO_BITRATE=800k
+Environment=BRAVE_PAWS_RECORDING_VIDEO_MAXRATE=1000k
+Environment=BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE=1600k
+Environment=BRAVE_PAWS_RECORDING_AUDIO_BITRATE=96k
 ExecStart=/usr/bin/env npm --prefix /mnt/q/repos/separation-tracker run server:start
 Restart=on-failure
 RestartSec=3

--- a/docs/2026-05-10-recording-metadata-v1-checklist.md
+++ b/docs/2026-05-10-recording-metadata-v1-checklist.md
@@ -9,4 +9,11 @@
 - [x] Add meaningful automated tests for payload, sidecar, and chapter generation flow.
 - [x] Build/lint/test the affected workspaces.
 - [x] Produce an end-to-end smoke-test recording artifact on Q proving the flow.
-- [ ] Commit sensible checkpoints, push branch, and open/update a PR.
+- [x] Commit sensible checkpoints, push branch, and open/update a PR.
+
+## Outputs
+
+- PR: https://github.com/harvey-cash/separation-tracker/pull/65
+- Smoke recording: `/mnt/q/fermi/brave-paws/smoke-tests/2026-05-10-recording-metadata-v1-rerun/server-data/recordings/2026/05/10/smoke-20260510T093538Z.mp4`
+- Smoke sidecar: `/mnt/q/fermi/brave-paws/smoke-tests/2026-05-10-recording-metadata-v1-rerun/server-data/recordings/2026/05/10/smoke-20260510T093538Z.brave-paws.json`
+- ffprobe chapter dump: `/mnt/q/fermi/brave-paws/smoke-tests/2026-05-10-recording-metadata-v1-rerun/ffprobe-chapters.json`

--- a/docs/2026-05-10-recording-metadata-v1-checklist.md
+++ b/docs/2026-05-10-recording-metadata-v1-checklist.md
@@ -1,0 +1,12 @@
+# Brave Paws recording metadata v1 checklist
+
+- [x] Inspect current app/server/deploy recording flow and choose the least-fragile insertion points.
+- [x] Add app-side runtime timeline event capture for active sessions, including actual step/session transitions.
+- [x] Extend recording API payloads/contracts so stop/finalization receives the session snapshot + timeline metadata.
+- [x] Implement server-side v1 sidecar generation adjacent to finalized MP4 recordings.
+- [x] Derive VLC-friendly chapters from actual runtime timeline events and embed them into the MP4 best-effort.
+- [x] Keep chapter embedding non-fatal so recordings are never lost on metadata failure.
+- [x] Add meaningful automated tests for payload, sidecar, and chapter generation flow.
+- [x] Build/lint/test the affected workspaces.
+- [x] Produce an end-to-end smoke-test recording artifact on Q proving the flow.
+- [ ] Commit sensible checkpoints, push branch, and open/update a PR.


### PR DESCRIPTION
## Summary
- capture real runtime session timeline events in the app and include them in the recording stop/finalization payload
- write a canonical `*.brave-paws.json` sidecar next to each saved MP4 and derive VLC-friendly chapters from that timeline
- embed MP4 chapters best-effort server-side, exposing sidecar/chapter metadata on the recording payload without risking the recording if embedding fails

## Testing
- `npm run app:lint`
- `npm run app:test`
- `npm run server:lint`
- `npm run server:test`
- `npm run build`

## Smoke artifact
- recording: `/mnt/q/fermi/brave-paws/smoke-tests/2026-05-10-recording-metadata-v1-rerun/server-data/recordings/2026/05/10/smoke-20260510T093538Z.mp4`
- sidecar: `/mnt/q/fermi/brave-paws/smoke-tests/2026-05-10-recording-metadata-v1-rerun/server-data/recordings/2026/05/10/smoke-20260510T093538Z.brave-paws.json`
- ffprobe chapters: `/mnt/q/fermi/brave-paws/smoke-tests/2026-05-10-recording-metadata-v1-rerun/ffprobe-chapters.json`
