### PR TITLE
fix: fail gracefully when QUANTUM is unreachable

### DIFF
--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -17,6 +17,7 @@ import { exportToCSV, parseCSV } from './utils/export';
 import { CAMERA_URL_STORAGE_KEY, getCameraUrlFromSearch } from './utils/cameraUrl';
 import { PAIRING_TOKEN_QUERY_PARAM, resolveCameraUrlFromPairingToken } from './utils/pairingToken';
 import { installGlobalClientDiagnostics } from './utils/clientDiagnostics';
+import { isLocalDevelopmentOrigin } from './config';
 import {
   ActiveSessionState,
   clearActiveSessionState,
@@ -104,6 +105,7 @@ export default function App() {
   }, [replaceSessions]);
 
   const storageSync = useStorageSync(sessions, handleImportSessions);
+  const isPublicBackendUnavailable = !storageSync.provider.isAvailable && !isLocalDevelopmentOrigin();
 
   useEffect(() => {
     const isTrainingActive = currentView === 'active' && Boolean(activeSession);
@@ -206,7 +208,7 @@ export default function App() {
               provider={storageSync.provider}
             />
           }
-          isBackendUnavailable={!storageSync.provider.isAvailable}
+          isBackendUnavailable={isPublicBackendUnavailable}
         />
       )}
 

--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -206,6 +206,7 @@ export default function App() {
               provider={storageSync.provider}
             />
           }
+          isBackendUnavailable={!storageSync.provider.isAvailable}
         />
       )}
 

--- a/apps/brave-paws-app/src/components/CameraStreamingControl.tsx
+++ b/apps/brave-paws-app/src/components/CameraStreamingControl.tsx
@@ -32,10 +32,10 @@ export function CameraStreamingControl({ control }: Props) {
           <p className="mt-2 text-sm text-slate-500">
             {isSupported
               ? 'Turn the live camera stream on before training, or switch it off when you only need the history.'
-              : capability.detail || 'This backend does not currently expose camera streaming control.'}
+              : error || capability.detail || 'This backend does not currently expose camera streaming control.'}
           </p>
 
-          {error && (
+          {error && isSupported && (
             <p className="mt-2 text-sm text-amber-700">{error}</p>
           )}
         </div>

--- a/apps/brave-paws-app/src/components/Dashboard.tsx
+++ b/apps/brave-paws-app/src/components/Dashboard.tsx
@@ -14,6 +14,7 @@ type Props = {
   onViewSession: (session: Session) => void;
   cameraStreamingControl?: ReactNode;
   storageSync?: ReactNode;
+  isBackendUnavailable?: boolean;
 };
 
 export function getRecentSessions(sessions: Session[]) {
@@ -31,6 +32,7 @@ export function Dashboard({
   onViewSession,
   cameraStreamingControl,
   storageSync,
+  isBackendUnavailable = false,
 }: Props) {
   const abortedSessions = sessions.filter((s) => s.status === 'aborted');
   const recentSessions = getRecentSessions(sessions);
@@ -60,15 +62,29 @@ export function Dashboard({
         </button>
       )}
 
+      {isBackendUnavailable && (
+        <section className="rounded-3xl border border-amber-200 bg-amber-50 p-5 sm:p-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-700">Private access required</p>
+          <p className="mt-2 text-sm text-amber-900">
+            Brave Paws needs a live connection to its private QUANTUM server before training, sync, camera controls, and recordings can work.
+            This public page cannot reach that server from the current network.
+          </p>
+        </section>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <button
           onClick={onStartNew}
-          className="group flex flex-col items-center justify-center gap-3 bg-rose-500 hover:bg-rose-600 text-white p-8 rounded-3xl shadow-sm hover:shadow-md transition-all"
+          disabled={isBackendUnavailable}
+          className="group flex flex-col items-center justify-center gap-3 bg-rose-500 hover:bg-rose-600 text-white p-8 rounded-3xl shadow-sm hover:shadow-md transition-all disabled:cursor-not-allowed disabled:bg-rose-200 disabled:text-rose-50 disabled:shadow-none"
         >
           <div className="bg-white/20 p-4 rounded-full group-hover:scale-110 transition-transform">
             <Play size={28} fill="currentColor" />
           </div>
           <span className="text-xl font-semibold">Start Training</span>
+          {isBackendUnavailable && (
+            <span className="text-center text-sm font-medium text-rose-50/90">Unavailable without QUANTUM access</span>
+          )}
         </button>
 
         <div className="grid grid-cols-2 gap-4">

--- a/apps/brave-paws-app/src/components/StorageSync.tsx
+++ b/apps/brave-paws-app/src/components/StorageSync.tsx
@@ -42,11 +42,11 @@ export function StorageSync({ provider }: Props) {
         {!provider.isAvailable && (
           <div className="flex items-start gap-2 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
             <AlertCircle size={16} className="shrink-0 mt-0.5" />
-            <span>QUANTUM is not reachable right now.</span>
+            <span>Live sync is unavailable on this public page because Brave Paws cannot reach its private QUANTUM server from this network.</span>
           </div>
         )}
 
-        {provider.error && (
+        {provider.error && provider.isAvailable && (
           <div className="flex items-start gap-2 rounded-2xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-700">
             <AlertCircle size={16} className="shrink-0 mt-0.5" />
             <span>{provider.error}</span>

--- a/apps/brave-paws-app/src/config.ts
+++ b/apps/brave-paws-app/src/config.ts
@@ -51,3 +51,12 @@ export function getDefaultCameraUrl(origin = getRuntimeOrigin()): string {
 export function getGoogleClientId(): string | undefined {
   return runtimeEnv.VITE_GOOGLE_CLIENT_ID;
 }
+
+export function isLocalDevelopmentOrigin(origin = getRuntimeOrigin()): boolean {
+  try {
+    const hostname = new URL(origin).hostname;
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+  } catch {
+    return false;
+  }
+}

--- a/apps/brave-paws-app/src/hooks/useCameraStreamingControl.ts
+++ b/apps/brave-paws-app/src/hooks/useCameraStreamingControl.ts
@@ -6,6 +6,7 @@ import {
   UNSUPPORTED_CAMERA_STREAMING_CAPABILITY,
   type CameraStreamingCapability,
 } from '../utils/backendCapabilities';
+import { isBackendUnavailableError } from '../utils/backendRequests';
 
 export type CameraStreamingControlState = {
   capability: CameraStreamingCapability;
@@ -16,6 +17,8 @@ export type CameraStreamingControlState = {
   setEnabled: (enabled: boolean, options?: { silent?: boolean }) => Promise<CameraStreamingCapability>;
   toggle: () => Promise<CameraStreamingCapability>;
 };
+
+const CAMERA_UNAVAILABLE_MESSAGE = 'Live camera controls are unavailable because Brave Paws cannot reach QUANTUM from this network.';
 
 export function useCameraStreamingControl(): CameraStreamingControlState {
   const [capability, setCapability] = useState<CameraStreamingCapability>(UNSUPPORTED_CAMERA_STREAMING_CAPABILITY);
@@ -33,7 +36,11 @@ export function useCameraStreamingControl(): CameraStreamingControlState {
       setError(null);
       return next;
     } catch (refreshError) {
-      const message = refreshError instanceof Error ? refreshError.message : 'Camera streaming control unavailable';
+      const message = isBackendUnavailableError(refreshError)
+        ? CAMERA_UNAVAILABLE_MESSAGE
+        : refreshError instanceof Error
+          ? refreshError.message
+          : 'Camera streaming control unavailable';
       setCapability(UNSUPPORTED_CAMERA_STREAMING_CAPABILITY);
       setError(message);
       throw refreshError;
@@ -55,7 +62,11 @@ export function useCameraStreamingControl(): CameraStreamingControlState {
       setError(null);
       return next;
     } catch (updateError) {
-      const message = updateError instanceof Error ? updateError.message : 'Could not update camera streaming';
+      const message = isBackendUnavailableError(updateError)
+        ? CAMERA_UNAVAILABLE_MESSAGE
+        : updateError instanceof Error
+          ? updateError.message
+          : 'Could not update camera streaming';
       if (!options?.silent) {
         setError(message);
       }

--- a/apps/brave-paws-app/src/hooks/useQuantumSync.ts
+++ b/apps/brave-paws-app/src/hooks/useQuantumSync.ts
@@ -4,6 +4,7 @@ import type { Session } from '../types';
 import { getApiBaseUrl } from '../config';
 import { mergeSessionsById, serializeSessionsForComparison } from '../utils/sessionSync';
 import { reportClientDiagnostic } from '../utils/clientDiagnostics';
+import { isBackendUnavailableError, parseBackendJsonResponse } from '../utils/backendRequests';
 
 export type SyncStatus = 'idle' | 'syncing' | 'success' | 'error';
 
@@ -82,14 +83,7 @@ function saveSyncMetadata(metadata: SyncMetadata) {
   localStorage.setItem(SYNC_METADATA_KEY, JSON.stringify(metadata));
 }
 
-async function parseJsonResponse<T>(response: Response): Promise<T> {
-  if (!response.ok) {
-    const detail = await response.text();
-    throw new Error(detail || `Request failed (${response.status})`);
-  }
-
-  return response.json() as Promise<T>;
-}
+const QUANTUM_UNAVAILABLE_MESSAGE = 'Live sync is unavailable because Brave Paws cannot reach QUANTUM from this network.';
 
 export function useQuantumSync(
   sessions: Session[],
@@ -151,7 +145,7 @@ export function useQuantumSync(
       body: JSON.stringify({ sessions: nextSessions }),
     });
 
-    return parseJsonResponse<PullResponse>(response);
+    return parseBackendJsonResponse<PullResponse>(response);
   }, [apiBaseUrl]);
 
   const pullSessions = useCallback(async () => {
@@ -163,7 +157,7 @@ export function useQuantumSync(
       body: JSON.stringify({}),
     });
 
-    return parseJsonResponse<PullResponse>(response);
+    return parseBackendJsonResponse<PullResponse>(response);
   }, [apiBaseUrl]);
 
   const pushNow = useCallback(async () => {
@@ -180,7 +174,11 @@ export function useQuantumSync(
       const response = await pushSessions(nextSessions);
       finishSuccess(nextSessions, response.updatedAt);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'QUANTUM sync failed';
+      const message = isBackendUnavailableError(error)
+        ? QUANTUM_UNAVAILABLE_MESSAGE
+        : error instanceof Error
+          ? error.message
+          : 'QUANTUM sync failed';
       setSyncStatus('error');
       setSyncError(message);
       setIsAvailable(false);
@@ -267,7 +265,11 @@ export function useQuantumSync(
         finishSuccess(localSessions, remote.updatedAt);
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'QUANTUM sync failed';
+      const message = isBackendUnavailableError(error)
+        ? QUANTUM_UNAVAILABLE_MESSAGE
+        : error instanceof Error
+          ? error.message
+          : 'QUANTUM sync failed';
       setSyncStatus('error');
       setSyncError(message);
       setIsAvailable(false);
@@ -295,16 +297,18 @@ export function useQuantumSync(
     const checkHealth = async () => {
       try {
         const response = await fetch(`${apiBaseUrl}health`);
-        if (!response.ok) {
-          throw new Error(`QUANTUM API unavailable (${response.status})`);
-        }
+        await parseBackendJsonResponse(response);
 
         if (!cancelled) {
           setIsAvailable(true);
         }
       } catch (error) {
         if (!cancelled) {
-          const message = error instanceof Error ? error.message : 'QUANTUM API unavailable';
+          const message = isBackendUnavailableError(error)
+            ? QUANTUM_UNAVAILABLE_MESSAGE
+            : error instanceof Error
+              ? error.message
+              : 'QUANTUM API unavailable';
           setIsAvailable(false);
           setSyncError(message);
           reportClientDiagnostic({

--- a/apps/brave-paws-app/src/utils/backendCapabilities.ts
+++ b/apps/brave-paws-app/src/utils/backendCapabilities.ts
@@ -1,5 +1,6 @@
 import { getApiBaseUrl } from '../config';
 import type { Session, SessionRecording, SessionTimelineEvent } from '../types';
+import { parseBackendJsonResponse } from './backendRequests';
 
 export type CameraStreamingCapability = {
   key: 'cameraStreaming';
@@ -52,21 +53,12 @@ export const UNSUPPORTED_SESSION_RECORDING_CAPABILITY: SessionRecordingCapabilit
   recording: null,
 };
 
-async function parseJsonResponse<T>(response: Response): Promise<T> {
-  if (!response.ok) {
-    const detail = await response.text();
-    throw new Error(detail || `Request failed (${response.status})`);
-  }
-
-  return response.json() as Promise<T>;
-}
-
 export async function fetchBackendCapabilities(
   fetchImpl: typeof fetch = fetch,
   apiBaseUrl = getApiBaseUrl(),
 ): Promise<BackendCapabilities> {
   const response = await fetchImpl(`${apiBaseUrl}capabilities`);
-  return parseJsonResponse<BackendCapabilities>(response);
+  return parseBackendJsonResponse<BackendCapabilities>(response);
 }
 
 export async function setCameraStreamingEnabled(
@@ -82,7 +74,7 @@ export async function setCameraStreamingEnabled(
     body: JSON.stringify({ enabled }),
   });
 
-  return parseJsonResponse<CameraStreamingCapability>(response);
+  return parseBackendJsonResponse<CameraStreamingCapability>(response);
 }
 
 export async function fetchSessionRecordingCapability(
@@ -90,7 +82,7 @@ export async function fetchSessionRecordingCapability(
   apiBaseUrl = getApiBaseUrl(),
 ): Promise<SessionRecordingCapability> {
   const response = await fetchImpl(`${apiBaseUrl}capabilities/recording`);
-  return parseJsonResponse<SessionRecordingCapability>(response);
+  return parseBackendJsonResponse<SessionRecordingCapability>(response);
 }
 
 export async function startSessionRecording(
@@ -106,7 +98,7 @@ export async function startSessionRecording(
     body: JSON.stringify(payload),
   });
 
-  return parseJsonResponse<SessionRecordingCapability>(response);
+  return parseBackendJsonResponse<SessionRecordingCapability>(response);
 }
 
 export async function stopSessionRecording(
@@ -127,5 +119,5 @@ export async function stopSessionRecording(
     body: JSON.stringify(payload),
   });
 
-  return parseJsonResponse<SessionRecordingCapability>(response);
+  return parseBackendJsonResponse<SessionRecordingCapability>(response);
 }

--- a/apps/brave-paws-app/src/utils/backendRequests.ts
+++ b/apps/brave-paws-app/src/utils/backendRequests.ts
@@ -31,12 +31,7 @@ function buildBackendFailureError(response: Response, bodyText: string): Backend
     });
   }
 
-  if (
-    response.status === 404
-    || response.status === 405
-    || response.status >= 500
-    || isHtmlLikeResponse(response, bodyText)
-  ) {
+  if (response.status >= 500 || isHtmlLikeResponse(response, bodyText)) {
     return new BackendRequestError('QUANTUM is not reachable right now.', {
       kind: 'unreachable',
       status: response.status,
@@ -78,5 +73,20 @@ export async function parseBackendJsonResponse<T>(response: Response): Promise<T
     );
   }
 
-  return response.json() as Promise<T>;
+  const clonedResponse = response.clone();
+
+  try {
+    return await response.json() as T;
+  } catch {
+    const bodyText = await clonedResponse.text().catch(() => '');
+    const htmlLike = isHtmlLikeResponse(response, bodyText);
+
+    throw new BackendRequestError(
+      htmlLike ? 'QUANTUM is not reachable right now.' : 'Unexpected response from QUANTUM.',
+      {
+        kind: htmlLike ? 'unreachable' : 'invalid-response',
+        status: response.status,
+      },
+    );
+  }
 }

--- a/apps/brave-paws-app/src/utils/backendRequests.ts
+++ b/apps/brave-paws-app/src/utils/backendRequests.ts
@@ -62,12 +62,14 @@ export async function parseBackendJsonResponse<T>(response: Response): Promise<T
 
   if (!isJsonContentType(contentType)) {
     const bodyText = await response.text();
+    const htmlLike = isHtmlLikeResponse(response, bodyText);
+    const message = htmlLike ? 'QUANTUM is not reachable right now.' : 'Unexpected response from QUANTUM.';
+    const kind: BackendRequestErrorKind = htmlLike ? 'unreachable' : 'invalid-response';
+
     throw new BackendRequestError(
-      isHtmlLikeResponse(response, bodyText)
-        ? 'QUANTUM is not reachable right now.'
-        : 'Unexpected response from QUANTUM.',
+      message,
       {
-        kind: isHtmlLikeResponse(response, bodyText) ? 'unreachable' : 'invalid-response',
+        kind,
         status: response.status,
       },
     );
@@ -80,11 +82,13 @@ export async function parseBackendJsonResponse<T>(response: Response): Promise<T
   } catch {
     const bodyText = await clonedResponse.text().catch(() => '');
     const htmlLike = isHtmlLikeResponse(response, bodyText);
+    const message = htmlLike ? 'QUANTUM is not reachable right now.' : 'Unexpected response from QUANTUM.';
+    const kind: BackendRequestErrorKind = htmlLike ? 'unreachable' : 'invalid-response';
 
     throw new BackendRequestError(
-      htmlLike ? 'QUANTUM is not reachable right now.' : 'Unexpected response from QUANTUM.',
+      message,
       {
-        kind: htmlLike ? 'unreachable' : 'invalid-response',
+        kind,
         status: response.status,
       },
     );

--- a/apps/brave-paws-app/src/utils/backendRequests.ts
+++ b/apps/brave-paws-app/src/utils/backendRequests.ts
@@ -1,0 +1,82 @@
+export type BackendRequestErrorKind = 'unreachable' | 'invalid-response' | 'request-failed';
+
+export class BackendRequestError extends Error {
+  kind: BackendRequestErrorKind;
+  status: number | null;
+
+  constructor(message: string, options: { kind: BackendRequestErrorKind; status?: number | null }) {
+    super(message);
+    this.name = 'BackendRequestError';
+    this.kind = options.kind;
+    this.status = options.status ?? null;
+  }
+}
+
+const HTML_PREFIX_PATTERN = /^\s*(<!doctype html|<html\b)/i;
+
+function isJsonContentType(contentType: string | null): boolean {
+  return Boolean(contentType && /(^|;)\s*application\/json\b/i.test(contentType));
+}
+
+function isHtmlLikeResponse(response: Response, bodyText: string): boolean {
+  const contentType = response.headers.get('content-type');
+  return /text\/html/i.test(contentType || '') || HTML_PREFIX_PATTERN.test(bodyText);
+}
+
+function buildBackendFailureError(response: Response, bodyText: string): BackendRequestError {
+  if (response.status === 401 || response.status === 403) {
+    return new BackendRequestError('This feature is unavailable right now.', {
+      kind: 'request-failed',
+      status: response.status,
+    });
+  }
+
+  if (
+    response.status === 404
+    || response.status === 405
+    || response.status >= 500
+    || isHtmlLikeResponse(response, bodyText)
+  ) {
+    return new BackendRequestError('QUANTUM is not reachable right now.', {
+      kind: 'unreachable',
+      status: response.status,
+    });
+  }
+
+  return new BackendRequestError('This feature is unavailable right now.', {
+    kind: 'request-failed',
+    status: response.status,
+  });
+}
+
+export function isBackendRequestError(error: unknown): error is BackendRequestError {
+  return error instanceof BackendRequestError;
+}
+
+export function isBackendUnavailableError(error: unknown): boolean {
+  return isBackendRequestError(error) && error.kind === 'unreachable';
+}
+
+export async function parseBackendJsonResponse<T>(response: Response): Promise<T> {
+  const contentType = response.headers.get('content-type');
+
+  if (!response.ok) {
+    const bodyText = await response.text();
+    throw buildBackendFailureError(response, bodyText);
+  }
+
+  if (!isJsonContentType(contentType)) {
+    const bodyText = await response.text();
+    throw new BackendRequestError(
+      isHtmlLikeResponse(response, bodyText)
+        ? 'QUANTUM is not reachable right now.'
+        : 'Unexpected response from QUANTUM.',
+      {
+        kind: isHtmlLikeResponse(response, bodyText) ? 'unreachable' : 'invalid-response',
+        status: response.status,
+      },
+    );
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/apps/brave-paws-app/src/utils/pairingToken.ts
+++ b/apps/brave-paws-app/src/utils/pairingToken.ts
@@ -1,5 +1,6 @@
 import { getApiBaseUrl } from '../config';
 import { buildCameraPairingUrl, type CameraStreamProfile } from './cameraUrl';
+import { parseBackendJsonResponse } from './backendRequests';
 
 export const PAIRING_TOKEN_QUERY_PARAM = 'pairingToken';
 const PAIRING_TOKEN_PATTERN = /^[A-Za-z0-9_-]{10,200}$/;
@@ -31,12 +32,7 @@ export async function resolveCameraUrlFromPairingToken(
   const fetchImpl = options.fetchImpl || fetch;
   const response = await fetchImpl(`${apiBaseUrl}pairings/${encodeURIComponent(token)}`);
 
-  if (!response.ok) {
-    const detail = await response.text();
-    throw new Error(detail || `Pairing lookup failed (${response.status})`);
-  }
-
-  const payload = await response.json() as PairingLookupResponse;
+  const payload = await parseBackendJsonResponse<PairingLookupResponse>(response);
   return buildCameraPairingUrl(payload.cameraUrl || '', undefined, {
     profile: payload.profile,
     mode: payload.mode,

--- a/apps/brave-paws-app/tests/backend-capabilities.test.ts
+++ b/apps/brave-paws-app/tests/backend-capabilities.test.ts
@@ -80,6 +80,16 @@ test('fetchBackendCapabilities hides raw HTML error bodies when the API is unrea
   );
 });
 
+test('fetchBackendCapabilities keeps JSON 404 responses as feature-unavailable errors', async () => {
+  await assert.rejects(
+    fetchBackendCapabilities((async () => new Response(JSON.stringify({ error: 'pairing disabled' }), {
+      status: 404,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    })) as typeof fetch, 'https://brave-paws.example/separation/api/'),
+    /This feature is unavailable right now\./,
+  );
+});
+
 test('fetchSessionRecordingCapability reads the dedicated recording capability endpoint', async () => {
   const capability = await fetchSessionRecordingCapability((async (input: string | URL | Request) => {
     assert.equal(String(input), 'https://brave-paws.example/separation/api/capabilities/recording');
@@ -150,6 +160,26 @@ test('setCameraStreamingEnabled hides non-JSON gateway errors behind a safe mess
       headers: { 'content-type': 'text/html' },
     })) as typeof fetch, 'https://brave-paws.example/separation/api/'),
     /QUANTUM is not reachable right now\./,
+  );
+});
+
+test('fetchBackendCapabilities hides invalid HTML payloads even when they claim JSON content-type', async () => {
+  await assert.rejects(
+    fetchBackendCapabilities((async () => new Response('<!DOCTYPE html><html><body>gateway error</body></html>', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch, 'https://brave-paws.example/separation/api/'),
+    /QUANTUM is not reachable right now\./,
+  );
+});
+
+test('fetchBackendCapabilities reports invalid non-HTML JSON payloads as unexpected responses', async () => {
+  await assert.rejects(
+    fetchBackendCapabilities((async () => new Response('{not-valid-json', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch, 'https://brave-paws.example/separation/api/'),
+    /Unexpected response from QUANTUM\./,
   );
 });
 

--- a/apps/brave-paws-app/tests/backend-capabilities.test.ts
+++ b/apps/brave-paws-app/tests/backend-capabilities.test.ts
@@ -70,6 +70,16 @@ test('setCameraStreamingEnabled posts the desired enabled state to the shared ca
   assert.equal(capability.supported, true);
 });
 
+test('fetchBackendCapabilities hides raw HTML error bodies when the API is unreachable', async () => {
+  await assert.rejects(
+    fetchBackendCapabilities((async () => new Response('<!DOCTYPE html><html><body>nope</body></html>', {
+      status: 404,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    })) as typeof fetch, 'https://brave-paws.example/separation/api/'),
+    /QUANTUM is not reachable right now\./,
+  );
+});
+
 test('fetchSessionRecordingCapability reads the dedicated recording capability endpoint', async () => {
   const capability = await fetchSessionRecordingCapability((async (input: string | URL | Request) => {
     assert.equal(String(input), 'https://brave-paws.example/separation/api/capabilities/recording');
@@ -131,6 +141,16 @@ test('startSessionRecording posts the session payload to the recording start end
 
   assert.equal(capability.active, true);
   assert.equal(capability.sessionId, 'session-abc');
+});
+
+test('setCameraStreamingEnabled hides non-JSON gateway errors behind a safe message', async () => {
+  await assert.rejects(
+    setCameraStreamingEnabled(true, (async () => new Response('<html><head><title>405 Not Allowed</title></head></html>', {
+      status: 405,
+      headers: { 'content-type': 'text/html' },
+    })) as typeof fetch, 'https://brave-paws.example/separation/api/'),
+    /QUANTUM is not reachable right now\./,
+  );
 });
 
 test('stopSessionRecording posts the stop payload to the recording stop endpoint', async () => {

--- a/apps/brave-paws-app/tests/dashboard-info-button.test.js
+++ b/apps/brave-paws-app/tests/dashboard-info-button.test.js
@@ -9,6 +9,10 @@ test('Dashboard includes info entry points, camera control, recording, and the v
   assert.match(dashboard, /recentSessions\.length === 0[\s\S]*New to separation anxiety training\?/);
   assert.match(dashboard, /recentSessions\.length > 0[\s\S]*About separation anxiety training/);
   assert.match(dashboard, /cameraStreamingControl/);
+  assert.match(dashboard, /Private access required/);
+  assert.match(dashboard, /cannot reach that server from the current network/);
+  assert.match(dashboard, /disabled=\{isBackendUnavailable\}/);
+  assert.match(dashboard, /Unavailable without QUANTUM access/);
   assert.match(dashboard, /Brave Paws v0\.2\.2/);
   assert.match(dashboard, /local QUANTUM Tailnet setup/);
   assert.match(dashboard, /backend camera control/);

--- a/apps/brave-paws-app/tests/pairing-token.test.ts
+++ b/apps/brave-paws-app/tests/pairing-token.test.ts
@@ -28,3 +28,16 @@ test('resolveCameraUrlFromPairingToken exchanges a token for a cached Brave Paws
   assert.match(pairedUrl, /cameraUrl=https%3A%2F%2Fprivate\.example%2Flive\.stream/);
   assert.match(pairedUrl, /cameraProfile=remote-low-latency/);
 });
+
+test('resolveCameraUrlFromPairingToken hides raw HTML failures behind a safe message', async () => {
+  await assert.rejects(
+    resolveCameraUrlFromPairingToken('?pairingToken=abc_DEF-1234567890', {
+      apiBaseUrl: 'https://brave-paws.example/separation/api/',
+      fetchImpl: async () => new Response('<!DOCTYPE html><html><body>GitHub Pages</body></html>', {
+        status: 404,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      }),
+    }),
+    /QUANTUM is not reachable right now\./,
+  );
+});


### PR DESCRIPTION
## Summary
- stop surfacing raw HTML and other non-JSON backend responses in the Brave Paws UI
- show a clear public-facing notice when the app cannot reach the private QUANTUM backend
- disable starting training from the public page when QUANTUM is unavailable

## What changed
- added a shared safe backend-response parser for the Brave Paws app
- normalized sync, camera-control, and pairing-token failures to generic non-secret-leaking messages
- hid duplicate low-level error text in the storage card when the backend is simply unavailable
- added a dashboard-level notice explaining that private QUANTUM access is required
- added regression tests for HTML/405 failure cases

## Validation
- npm run app:test
- npm run app:lint
- npm run build