### PR TITLE
fix: recheck backend state on pageshow

### DIFF
--- a/apps/brave-paws-app/src/hooks/useCameraStreamingControl.ts
+++ b/apps/brave-paws-app/src/hooks/useCameraStreamingControl.ts
@@ -30,6 +30,8 @@ export function useCameraStreamingControl(): CameraStreamingControlState {
   capabilityRef.current = capability;
 
   const refresh = useCallback(async () => {
+    setIsLoading(true);
+
     try {
       const next = (await fetchBackendCapabilities()).cameraStreaming;
       setCapability(next);
@@ -85,6 +87,28 @@ export function useCameraStreamingControl(): CameraStreamingControlState {
     void refresh().catch(() => {
       // The dashboard can show a graceful unavailable state.
     });
+
+    const handleResume = () => {
+      if (document.visibilityState === 'hidden') {
+        return;
+      }
+
+      void refresh().catch(() => {
+        // The dashboard can show a graceful unavailable state.
+      });
+    };
+
+    window.addEventListener('focus', handleResume);
+    window.addEventListener('online', handleResume);
+    window.addEventListener('pageshow', handleResume);
+    document.addEventListener('visibilitychange', handleResume);
+
+    return () => {
+      window.removeEventListener('focus', handleResume);
+      window.removeEventListener('online', handleResume);
+      window.removeEventListener('pageshow', handleResume);
+      document.removeEventListener('visibilitychange', handleResume);
+    };
   }, [refresh]);
 
   return {

--- a/apps/brave-paws-app/src/hooks/useCameraStreamingControl.ts
+++ b/apps/brave-paws-app/src/hooks/useCameraStreamingControl.ts
@@ -26,10 +26,16 @@ export function useCameraStreamingControl(): CameraStreamingControlState {
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const capabilityRef = useRef(capability);
+  const refreshInFlightRef = useRef(false);
 
   capabilityRef.current = capability;
 
   const refresh = useCallback(async () => {
+    if (refreshInFlightRef.current) {
+      return capabilityRef.current;
+    }
+
+    refreshInFlightRef.current = true;
     setIsLoading(true);
 
     try {
@@ -47,6 +53,7 @@ export function useCameraStreamingControl(): CameraStreamingControlState {
       setError(message);
       throw refreshError;
     } finally {
+      refreshInFlightRef.current = false;
       setIsLoading(false);
     }
   }, []);

--- a/apps/brave-paws-app/src/hooks/useQuantumSync.ts
+++ b/apps/brave-paws-app/src/hooks/useQuantumSync.ts
@@ -385,12 +385,14 @@ export function useQuantumSync(
 
     window.addEventListener('focus', handleResume);
     window.addEventListener('online', handleResume);
+    window.addEventListener('pageshow', handleResume);
     document.addEventListener('visibilitychange', handleResume);
 
     return () => {
       cancelled = true;
       window.removeEventListener('focus', handleResume);
       window.removeEventListener('online', handleResume);
+      window.removeEventListener('pageshow', handleResume);
       document.removeEventListener('visibilitychange', handleResume);
     };
   }, [apiBaseUrl, hydrateFromRemote]);

--- a/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
+++ b/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
@@ -19,6 +19,7 @@ test('camera streaming control rechecks backend capabilities on resume-style bro
   const hook = readFileSync(resolve(process.cwd(), 'src/hooks/useCameraStreamingControl.ts'), 'utf8');
 
   assert.match(hook, /setIsLoading\(true\);/);
+  assert.match(hook, /refreshInFlightRef/);
   assert.match(hook, /window\.addEventListener\('focus', handleResume\);/);
   assert.match(hook, /window\.addEventListener\('online', handleResume\);/);
   assert.match(hook, /window\.addEventListener\('pageshow', handleResume\);/);

--- a/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
+++ b/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
@@ -13,3 +13,15 @@ test('App wires camera streaming control into the dashboard and active session l
   assert.match(app, /pendingSessionCameraStateRef\.current = false/);
   assert.match(app, /setEnabled\(pendingState, \{ silent: true \}\)/);
 });
+
+
+test('camera streaming control rechecks backend capabilities on resume-style browser events', () => {
+  const hook = readFileSync(resolve(process.cwd(), 'src/hooks/useCameraStreamingControl.ts'), 'utf8');
+
+  assert.match(hook, /setIsLoading\(true\);/);
+  assert.match(hook, /window\.addEventListener\('focus', handleResume\);/);
+  assert.match(hook, /window\.addEventListener\('online', handleResume\);/);
+  assert.match(hook, /window\.addEventListener\('pageshow', handleResume\);/);
+  assert.match(hook, /document\.addEventListener\('visibilitychange', handleResume\);/);
+  assert.match(hook, /window\.removeEventListener\('pageshow', handleResume\);/);
+});

--- a/apps/brave-paws-app/tests/quantum-sync-regression.test.js
+++ b/apps/brave-paws-app/tests/quantum-sync-regression.test.js
@@ -18,3 +18,14 @@ test('useQuantumSync dereferences onReplaceSessions through a ref instead of eff
   assert.match(hookSource, /onReplaceSessionsRef\.current\(nextSessions\);/);
   assert.doesNotMatch(hookSource, /\[finishSuccess, onReplaceSessions, pullSessions, scheduleAutoPush\]/);
 });
+
+
+test('useQuantumSync rehydrates on pageshow as well as the existing resume signals', () => {
+  const hookSource = readFileSync(resolve(process.cwd(), 'src/hooks/useQuantumSync.ts'), 'utf8');
+
+  assert.match(hookSource, /window\.addEventListener\('focus', handleResume\);/);
+  assert.match(hookSource, /window\.addEventListener\('online', handleResume\);/);
+  assert.match(hookSource, /window\.addEventListener\('pageshow', handleResume\);/);
+  assert.match(hookSource, /document\.addEventListener\('visibilitychange', handleResume\);/);
+  assert.match(hookSource, /window\.removeEventListener\('pageshow', handleResume\);/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -315,7 +315,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -332,7 +331,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -349,7 +347,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -366,7 +363,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -383,7 +379,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -400,7 +395,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -417,7 +411,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -434,7 +427,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -451,7 +443,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -468,7 +459,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -485,7 +475,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -502,7 +491,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -519,7 +507,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -536,7 +523,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -553,7 +539,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,7 +555,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,7 +571,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -604,7 +587,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,7 +603,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -638,7 +619,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -655,7 +635,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -672,7 +651,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -689,7 +667,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,7 +683,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,7 +699,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,7 +715,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary
- recheck camera capabilities when the page resumes via focus, online, visibilitychange, or pageshow
- add pageshow-triggered sync hydration so browser restores and refresh-style resumes pull fresh backend state
- show camera refresh activity while a manual capability check is in flight and lock the behaviour in regression tests

## Testing
- npm run app:test
- npm run app:lint
- npm run app:build