### PR TITLE
feat: support configurable Brave Paws backend roots

### DIFF
--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -11,10 +11,12 @@ import { SessionView } from './components/SessionView';
 import { InfoView } from './components/InfoView';
 import { CameraStreamingControl } from './components/CameraStreamingControl';
 import { StorageSync } from './components/StorageSync';
+import { BackendConnectionSettings } from './components/BackendConnectionSettings';
 import { useCameraStreamingControl } from './hooks/useCameraStreamingControl';
 import { useStorageSync } from './hooks/useStorageSync';
 import { exportToCSV, parseCSV } from './utils/export';
 import { CAMERA_URL_STORAGE_KEY, getCameraUrlFromSearch } from './utils/cameraUrl';
+import { loadStoredBackendRootUrl } from './config';
 import { PAIRING_TOKEN_QUERY_PARAM, resolveCameraUrlFromPairingToken } from './utils/pairingToken';
 import { installGlobalClientDiagnostics } from './utils/clientDiagnostics';
 import {
@@ -45,6 +47,7 @@ export default function App() {
   const [activeSession, setActiveSession] = useState<Session | null>(restoredActiveSessionState?.session ?? null);
   const [activeSessionState, setActiveSessionState] = useState<ActiveSessionState | null>(restoredActiveSessionState);
   const [cameraUrl, setCameraUrl] = useState(() => getCameraUrlFromSearch(window.location.search) || localStorage.getItem(CAMERA_URL_STORAGE_KEY) || '');
+  const [backendRootUrl, setBackendRootUrl] = useState<string | null>(() => loadStoredBackendRootUrl());
   const cameraStreamingControl = useCameraStreamingControl();
   const wasTrainingActiveRef = useRef(false);
   const pendingSessionCameraStateRef = useRef<boolean | null>(restoredActiveSessionState ? true : null);
@@ -83,7 +86,7 @@ export default function App() {
     };
 
     void applyPairingFromLocation();
-  }, []);
+  }, [backendRootUrl]);
 
   // Keep cameraUrl in sync with local storage
   useEffect(() => {
@@ -204,6 +207,13 @@ export default function App() {
           storageSync={
             <StorageSync
               provider={storageSync.provider}
+              backendConnection={
+                <BackendConnectionSettings
+                  currentBackendRootUrl={backendRootUrl}
+                  isBackendAvailable={storageSync.provider.isAvailable}
+                  onBackendRootUrlChange={setBackendRootUrl}
+                />
+              }
             />
           }
         />

--- a/apps/brave-paws-app/src/components/BackendConnectionSettings.tsx
+++ b/apps/brave-paws-app/src/components/BackendConnectionSettings.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AlertCircle, CheckCircle2, Loader2, RotateCcw, Server, Wifi } from 'lucide-react';
+import {
+  clearStoredBackendRootUrl,
+  getApiBaseUrlForBackendRoot,
+  getDefaultCameraUrlForBackendRoot,
+  getDeploymentApiBaseUrl,
+  getDeploymentDefaultCameraUrl,
+  normalizeBackendRootUrl,
+  saveStoredBackendRootUrl,
+} from '../config';
+
+type Props = {
+  currentBackendRootUrl: string | null;
+  isBackendAvailable: boolean;
+  onBackendRootUrlChange: (backendRootUrl: string | null) => void;
+};
+
+type ConnectionStatus = 'idle' | 'testing' | 'saved' | 'error';
+
+export function BackendConnectionSettings({
+  currentBackendRootUrl,
+  isBackendAvailable,
+  onBackendRootUrlChange,
+}: Props) {
+  const [draftValue, setDraftValue] = useState(currentBackendRootUrl || '');
+  const [status, setStatus] = useState<ConnectionStatus>('idle');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    setDraftValue(currentBackendRootUrl || '');
+
+    if (!currentBackendRootUrl) {
+      setStatus('idle');
+      setMessage('');
+    }
+  }, [currentBackendRootUrl]);
+
+  const normalizedDraftValue = normalizeBackendRootUrl(draftValue);
+  const previewBackendRoot = normalizedDraftValue || currentBackendRootUrl || '';
+  const previewApiBaseUrl = previewBackendRoot ? getApiBaseUrlForBackendRoot(previewBackendRoot) : getDeploymentApiBaseUrl();
+  const previewCameraUrl = previewBackendRoot ? getDefaultCameraUrlForBackendRoot(previewBackendRoot) : getDeploymentDefaultCameraUrl();
+  const deploymentHint = useMemo(() => getDeploymentApiBaseUrl(), []);
+  const needsFirstRunSetup = !currentBackendRootUrl && !isBackendAvailable;
+
+  const handleTestAndSave = async () => {
+    const normalized = normalizeBackendRootUrl(draftValue);
+    if (!normalized) {
+      setStatus('error');
+      setMessage('Enter a full backend root like https://quantum.tail080401.ts.net:7447');
+      return;
+    }
+
+    setStatus('testing');
+    setMessage('Testing the backend connection…');
+
+    try {
+      const healthUrl = new URL('health', getApiBaseUrlForBackendRoot(normalized)).toString();
+      const response = await fetch(healthUrl);
+      if (!response.ok) {
+        throw new Error(`Backend health check failed (${response.status})`);
+      }
+
+      const saved = saveStoredBackendRootUrl(normalized);
+      onBackendRootUrlChange(saved);
+      setDraftValue(saved || normalized);
+      setStatus('saved');
+      setMessage('Connected. Brave Paws will keep using this backend in this browser.');
+    } catch (error) {
+      setStatus('error');
+      setMessage(error instanceof Error ? error.message : 'Could not reach that backend.');
+    }
+  };
+
+  const handleReset = () => {
+    clearStoredBackendRootUrl();
+    onBackendRootUrlChange(null);
+    setDraftValue('');
+    setStatus('idle');
+    setMessage('Reset to the deployment default backend.');
+  };
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4 sm:p-5">
+      <div className="flex items-start gap-3">
+        <div className="rounded-2xl bg-sky-100 p-2.5 text-sky-600">
+          <Wifi size={18} />
+        </div>
+        <div>
+          <h3 className="text-sm font-bold text-slate-800">Backend connection</h3>
+          <p className="mt-1 text-xs text-slate-500">
+            QUANTUM staging can keep the deployment default. For the static <span className="font-semibold text-slate-700">harvey.cash</span> app,
+            save your QUANTUM Tailnet root once and Brave Paws will derive the API and suggested camera link from it.
+          </p>
+        </div>
+      </div>
+
+      {needsFirstRunSetup && (
+        <div className="flex items-start gap-2 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          <AlertCircle size={16} className="mt-0.5 shrink-0" />
+          <div>
+            <p className="font-semibold">Connect to your Brave Paws backend</p>
+            <p className="mt-1 text-xs text-amber-800">
+              This frontend cannot see a same-origin backend right now. Enter your QUANTUM Tailnet root URL to point the static app at your private backend.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <label htmlFor="backend-root-url" className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+          Backend server URL
+        </label>
+        <input
+          id="backend-root-url"
+          type="url"
+          value={draftValue}
+          onChange={(event) => {
+            setDraftValue(event.target.value);
+            if (status !== 'testing') {
+              setStatus('idle');
+              setMessage('');
+            }
+          }}
+          placeholder="https://quantum.tail080401.ts.net:7447"
+          className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-sky-300 focus:bg-white focus:ring-2 focus:ring-sky-100"
+        />
+        <p className="text-xs text-slate-500">
+          Current deployment default: <span className="font-mono text-[11px] text-slate-600">{deploymentHint}</span>
+        </p>
+      </div>
+
+      <div className="grid gap-2 text-xs text-slate-500 sm:grid-cols-2">
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+          <p className="font-semibold uppercase tracking-[0.14em] text-slate-400">API base</p>
+          <p className="mt-1 break-all font-mono text-[11px] text-slate-600">{previewApiBaseUrl}</p>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+          <p className="font-semibold uppercase tracking-[0.14em] text-slate-400">Suggested camera link</p>
+          <p className="mt-1 break-all font-mono text-[11px] text-slate-600">{previewCameraUrl}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => void handleTestAndSave()}
+          disabled={status === 'testing'}
+          className="inline-flex items-center gap-2 rounded-xl bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-sky-700 disabled:cursor-not-allowed disabled:bg-sky-300"
+        >
+          {status === 'testing' ? <Loader2 size={15} className="animate-spin" /> : <Server size={15} />}
+          Test &amp; Save
+        </button>
+        <button
+          type="button"
+          onClick={handleReset}
+          disabled={status === 'testing' && !currentBackendRootUrl}
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RotateCcw size={15} />
+          Reset to deployment default
+        </button>
+      </div>
+
+      {message && (
+        <div
+          className={`flex items-start gap-2 rounded-2xl px-4 py-3 text-sm ${
+            status === 'saved'
+              ? 'border border-emerald-200 bg-emerald-50 text-emerald-800'
+              : status === 'error'
+                ? 'border border-red-200 bg-red-50 text-red-700'
+                : 'border border-slate-200 bg-slate-50 text-slate-600'
+          }`}
+        >
+          {status === 'saved' ? (
+            <CheckCircle2 size={16} className="mt-0.5 shrink-0" />
+          ) : status === 'error' ? (
+            <AlertCircle size={16} className="mt-0.5 shrink-0" />
+          ) : (
+            <Loader2 size={16} className="mt-0.5 shrink-0 animate-spin" />
+          )}
+          <span>{message}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/brave-paws-app/src/components/BackendConnectionSettings.tsx
+++ b/apps/brave-paws-app/src/components/BackendConnectionSettings.tsx
@@ -115,6 +115,7 @@ export function BackendConnectionSettings({
           id="backend-root-url"
           type="url"
           value={draftValue}
+          disabled={status === 'testing'}
           onChange={(event) => {
             setDraftValue(event.target.value);
             if (status !== 'testing') {
@@ -123,7 +124,7 @@ export function BackendConnectionSettings({
             }
           }}
           placeholder="https://quantum.tail080401.ts.net:7447"
-          className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-sky-300 focus:bg-white focus:ring-2 focus:ring-sky-100"
+          className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-sky-300 focus:bg-white focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:opacity-60"
         />
         <p className="text-xs text-slate-500">
           Current deployment default: <span className="font-mono text-[11px] text-slate-600">{deploymentHint}</span>
@@ -154,7 +155,7 @@ export function BackendConnectionSettings({
         <button
           type="button"
           onClick={handleReset}
-          disabled={status === 'testing' && !currentBackendRootUrl}
+          disabled={status === 'testing'}
           className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
         >
           <RotateCcw size={15} />

--- a/apps/brave-paws-app/src/components/StorageSync.tsx
+++ b/apps/brave-paws-app/src/components/StorageSync.tsx
@@ -1,12 +1,14 @@
+import { type ReactNode } from 'react';
 import { AlertCircle, Check, Loader2, RefreshCw, Server } from 'lucide-react';
 
 import type { StorageProviderState } from '../hooks/useStorageSync';
 
 type Props = {
   provider: StorageProviderState;
+  backendConnection?: ReactNode;
 };
 
-export function StorageSync({ provider }: Props) {
+export function StorageSync({ provider, backendConnection }: Props) {
   return (
     <section className="bg-white rounded-3xl shadow-sm border border-slate-100 p-6 space-y-5">
       <div className="flex items-start justify-between gap-4">
@@ -58,6 +60,8 @@ export function StorageSync({ provider }: Props) {
           <div className="rounded-2xl border border-slate-200 bg-white px-3 py-2">After saves and edits</div>
           <div className="rounded-2xl border border-slate-200 bg-white px-3 py-2">After CSV imports</div>
         </div>
+
+        {backendConnection}
 
         {provider.onSyncNow && (
           <div className="flex flex-wrap gap-2">

--- a/apps/brave-paws-app/src/config.ts
+++ b/apps/brave-paws-app/src/config.ts
@@ -1,4 +1,11 @@
 type RuntimeEnv = Record<string, string | undefined>;
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+type ResolveUrlOptions = {
+  env?: RuntimeEnv;
+  origin?: string;
+  storage?: StorageLike | null;
+};
 
 const runtimeEnv = ((import.meta as unknown as { env?: RuntimeEnv }).env ?? {}) as RuntimeEnv;
 
@@ -7,6 +14,7 @@ const DEFAULT_PUBLIC_BASE_PATH = '/separation/';
 const DEFAULT_APP_BASE_PATH = '/separation/app/';
 const DEFAULT_API_BASE_PATH = '/separation/api/';
 const DEFAULT_CAMERA_BASE_PATH = '/separation/camera/live.stream/';
+export const BACKEND_ROOT_URL_STORAGE_KEY = 'brave_paws_backend_root_url';
 
 function getRuntimeOrigin(): string {
   if (typeof window !== 'undefined' && window.location?.origin) {
@@ -16,8 +24,43 @@ function getRuntimeOrigin(): string {
   return FALLBACK_ORIGIN;
 }
 
+function getStorage(): StorageLike | null {
+  if (typeof localStorage === 'undefined') {
+    return null;
+  }
+
+  return localStorage;
+}
+
 function ensureTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '') + '/';
+}
+
+function isSupportedBackendProtocol(url: URL): boolean {
+  const isLocalhost =
+    url.hostname === 'localhost' ||
+    url.hostname === '127.0.0.1' ||
+    url.hostname === '::1';
+
+  return url.protocol === 'https:' || (isLocalhost && url.protocol === 'http:');
+}
+
+export function normalizeBackendRootUrl(value: string, _origin = getRuntimeOrigin()): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.username || url.password || !isSupportedBackendProtocol(url)) {
+      return '';
+    }
+
+    return url.origin;
+  } catch {
+    return '';
+  }
 }
 
 function resolveConfiguredUrl(value: string | undefined, fallbackPath: string, origin = getRuntimeOrigin()): string {
@@ -32,22 +75,131 @@ function resolveConfiguredUrl(value: string | undefined, fallbackPath: string, o
   return ensureTrailingSlash(new URL(fallbackPath, origin).toString());
 }
 
+function resolveBackendDerivedUrl(backendRootUrl: string, fallbackPath: string): string {
+  return ensureTrailingSlash(new URL(fallbackPath, ensureTrailingSlash(backendRootUrl)).toString());
+}
+
+export function loadStoredBackendRootUrl(options: { origin?: string; storage?: StorageLike | null } = {}): string | null {
+  const storage = options.storage === undefined ? getStorage() : options.storage;
+  if (!storage) {
+    return null;
+  }
+
+  const normalized = normalizeBackendRootUrl(storage.getItem(BACKEND_ROOT_URL_STORAGE_KEY) || '', options.origin);
+  return normalized || null;
+}
+
+export function saveStoredBackendRootUrl(value: string, options: { origin?: string; storage?: StorageLike | null } = {}): string | null {
+  const normalized = normalizeBackendRootUrl(value, options.origin);
+  const storage = options.storage === undefined ? getStorage() : options.storage;
+
+  if (!storage) {
+    return normalized || null;
+  }
+
+  if (normalized) {
+    storage.setItem(BACKEND_ROOT_URL_STORAGE_KEY, normalized);
+    return normalized;
+  }
+
+  storage.removeItem(BACKEND_ROOT_URL_STORAGE_KEY);
+  return null;
+}
+
+export function clearStoredBackendRootUrl(storage: StorageLike | null = getStorage()) {
+  storage?.removeItem(BACKEND_ROOT_URL_STORAGE_KEY);
+}
+
+export function resolveEffectiveBackendRootUrl(options: ResolveUrlOptions = {}): string | null {
+  const origin = options.origin ?? getRuntimeOrigin();
+  const env = options.env ?? runtimeEnv;
+  const runtimeOverride = loadStoredBackendRootUrl({ origin, storage: options.storage });
+
+  if (runtimeOverride) {
+    return runtimeOverride;
+  }
+
+  const envOverride = normalizeBackendRootUrl(env.VITE_BRAVE_PAWS_BACKEND_ROOT_URL || '', origin);
+  return envOverride || null;
+}
+
+export function getEffectiveBackendRootUrl(origin = getRuntimeOrigin()): string | null {
+  return resolveEffectiveBackendRootUrl({ origin });
+}
+
+export function getDeploymentPublicBaseUrl(origin = getRuntimeOrigin(), env = runtimeEnv): string {
+  return resolveConfiguredUrl(env.VITE_BRAVE_PAWS_PUBLIC_BASE_URL, DEFAULT_PUBLIC_BASE_PATH, origin);
+}
+
 export function getPublicBaseUrl(origin = getRuntimeOrigin()): string {
-  return resolveConfiguredUrl(runtimeEnv.VITE_BRAVE_PAWS_PUBLIC_BASE_URL, DEFAULT_PUBLIC_BASE_PATH, origin);
+  return getDeploymentPublicBaseUrl(origin);
+}
+
+export function getDeploymentAppUrl(origin = getRuntimeOrigin(), env = runtimeEnv): string {
+  return resolveConfiguredUrl(env.VITE_BRAVE_PAWS_APP_URL, DEFAULT_APP_BASE_PATH, origin);
 }
 
 export function getAppUrl(origin = getRuntimeOrigin()): string {
-  return resolveConfiguredUrl(runtimeEnv.VITE_BRAVE_PAWS_APP_URL, DEFAULT_APP_BASE_PATH, origin);
+  return getDeploymentAppUrl(origin);
+}
+
+export function getApiBaseUrlForBackendRoot(backendRootUrl: string): string {
+  return resolveBackendDerivedUrl(backendRootUrl, DEFAULT_API_BASE_PATH);
+}
+
+export function getDefaultCameraUrlForBackendRoot(backendRootUrl: string): string {
+  return resolveBackendDerivedUrl(backendRootUrl, DEFAULT_CAMERA_BASE_PATH);
+}
+
+export function resolveApiBaseUrl(options: ResolveUrlOptions = {}): string {
+  const origin = options.origin ?? getRuntimeOrigin();
+  const env = options.env ?? runtimeEnv;
+  const backendRootUrl = resolveEffectiveBackendRootUrl({ ...options, origin, env });
+
+  if (backendRootUrl) {
+    return getApiBaseUrlForBackendRoot(backendRootUrl);
+  }
+
+  return resolveConfiguredUrl(env.VITE_BRAVE_PAWS_API_BASE_URL, DEFAULT_API_BASE_PATH, origin);
+}
+
+export function getDeploymentApiBaseUrl(origin = getRuntimeOrigin(), env = runtimeEnv): string {
+  return resolveConfiguredUrl(env.VITE_BRAVE_PAWS_API_BASE_URL, DEFAULT_API_BASE_PATH, origin);
 }
 
 export function getApiBaseUrl(origin = getRuntimeOrigin()): string {
-  return resolveConfiguredUrl(runtimeEnv.VITE_BRAVE_PAWS_API_BASE_URL, DEFAULT_API_BASE_PATH, origin);
+  return resolveApiBaseUrl({ origin });
+}
+
+export function resolveDefaultCameraUrl(options: ResolveUrlOptions = {}): string {
+  const origin = options.origin ?? getRuntimeOrigin();
+  const env = options.env ?? runtimeEnv;
+  const backendRootUrl = resolveEffectiveBackendRootUrl({ ...options, origin, env });
+
+  if (backendRootUrl) {
+    return getDefaultCameraUrlForBackendRoot(backendRootUrl);
+  }
+
+  return resolveConfiguredUrl(env.VITE_BRAVE_PAWS_DEFAULT_CAMERA_URL, DEFAULT_CAMERA_BASE_PATH, origin);
+}
+
+export function getDeploymentDefaultCameraUrl(origin = getRuntimeOrigin(), env = runtimeEnv): string {
+  return resolveConfiguredUrl(env.VITE_BRAVE_PAWS_DEFAULT_CAMERA_URL, DEFAULT_CAMERA_BASE_PATH, origin);
 }
 
 export function getDefaultCameraUrl(origin = getRuntimeOrigin()): string {
-  return resolveConfiguredUrl(runtimeEnv.VITE_BRAVE_PAWS_DEFAULT_CAMERA_URL, DEFAULT_CAMERA_BASE_PATH, origin);
+  return resolveDefaultCameraUrl({ origin });
 }
 
 export function getGoogleClientId(): string | undefined {
   return runtimeEnv.VITE_GOOGLE_CLIENT_ID;
+}
+
+export function isLocalDevelopmentOrigin(origin = getRuntimeOrigin()): boolean {
+  try {
+    const hostname = new URL(origin).hostname;
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+  } catch {
+    return false;
+  }
 }

--- a/apps/brave-paws-app/tests/backend-connection-ui.test.js
+++ b/apps/brave-paws-app/tests/backend-connection-ui.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+test('dashboard storage sync includes backend connection settings with test, save, and reset affordances', () => {
+  const storageSync = readFileSync(resolve(process.cwd(), 'src/components/StorageSync.tsx'), 'utf8');
+  const backendConnection = readFileSync(resolve(process.cwd(), 'src/components/BackendConnectionSettings.tsx'), 'utf8');
+
+  assert.match(storageSync, /backendConnection/);
+  assert.match(backendConnection, /Backend connection/);
+  assert.match(backendConnection, /Backend server URL/);
+  assert.match(backendConnection, /Test &amp; Save/);
+  assert.match(backendConnection, /Reset to deployment default/);
+});
+
+test('backend connection settings guide the static frontend failure path', () => {
+  const backendConnection = readFileSync(resolve(process.cwd(), 'src/components/BackendConnectionSettings.tsx'), 'utf8');
+
+  assert.match(backendConnection, /Connect to your Brave Paws backend/);
+  assert.match(backendConnection, /static <span className="font-semibold text-slate-700">harvey\.cash<\/span> app/i);
+  assert.match(backendConnection, /QUANTUM Tailnet root URL/i);
+  assert.match(backendConnection, /Suggested camera link/);
+});

--- a/apps/brave-paws-app/tests/runtime-backend-config.test.ts
+++ b/apps/brave-paws-app/tests/runtime-backend-config.test.ts
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  BACKEND_ROOT_URL_STORAGE_KEY,
+  clearStoredBackendRootUrl,
+  loadStoredBackendRootUrl,
+  resolveApiBaseUrl,
+  resolveDefaultCameraUrl,
+  saveStoredBackendRootUrl,
+} from '../src/config.ts';
+
+type StorageLike = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+};
+
+function createStorage(initialEntries: Record<string, string> = {}): StorageLike {
+  const store = new Map(Object.entries(initialEntries));
+
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+}
+
+test('runtime backend override beats build-time API env config', () => {
+  const storage = createStorage();
+  saveStoredBackendRootUrl('https://quantum.tail080401.ts.net:7447/separation/app/', { storage });
+
+  assert.equal(
+    resolveApiBaseUrl({
+      origin: 'https://harvey.cash',
+      env: {
+        VITE_BRAVE_PAWS_API_BASE_URL: 'https://env.example/separation/api/',
+      },
+      storage,
+    }),
+    'https://quantum.tail080401.ts.net:7447/separation/api/',
+  );
+});
+
+test('build-time API env config beats same-origin fallback when no runtime override is saved', () => {
+  const storage = createStorage();
+
+  assert.equal(
+    resolveApiBaseUrl({
+      origin: 'https://harvey.cash',
+      env: {
+        VITE_BRAVE_PAWS_API_BASE_URL: 'https://env.example/separation/api/',
+      },
+      storage,
+    }),
+    'https://env.example/separation/api/',
+  );
+});
+
+test('malformed runtime backend override is ignored safely', () => {
+  const storage = createStorage({
+    [BACKEND_ROOT_URL_STORAGE_KEY]: 'definitely not a valid url',
+  });
+
+  assert.equal(
+    resolveApiBaseUrl({
+      origin: 'https://harvey.cash',
+      env: {
+        VITE_BRAVE_PAWS_API_BASE_URL: 'https://env.example/separation/api/',
+      },
+      storage,
+    }),
+    'https://env.example/separation/api/',
+  );
+});
+
+test('default camera URL follows the saved runtime backend root', () => {
+  const storage = createStorage();
+  saveStoredBackendRootUrl('https://quantum.tail080401.ts.net:7447', { storage });
+
+  assert.equal(
+    resolveDefaultCameraUrl({
+      origin: 'https://harvey.cash',
+      storage,
+    }),
+    'https://quantum.tail080401.ts.net:7447/separation/camera/live.stream/',
+  );
+});
+
+test('reset removes the saved backend root override', () => {
+  const storage = createStorage();
+  saveStoredBackendRootUrl('https://quantum.tail080401.ts.net:7447', { storage });
+  assert.equal(loadStoredBackendRootUrl({ storage }), 'https://quantum.tail080401.ts.net:7447');
+
+  clearStoredBackendRootUrl(storage);
+
+  assert.equal(loadStoredBackendRootUrl({ storage }), null);
+});

--- a/apps/brave-paws-server/src/config.ts
+++ b/apps/brave-paws-server/src/config.ts
@@ -29,6 +29,29 @@ function normalizeBaseUrl(value: string | undefined): string | null {
   }
 }
 
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function parseCorsAllowedOrigins(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .split(',')
+        .map((entry) => normalizeOrigin(entry.trim()))
+        .filter((entry): entry is string => Boolean(entry)),
+    ),
+  );
+}
+
 export type BravePawsServerConfig = {
   host: string;
   port: number;
@@ -58,6 +81,7 @@ export type BravePawsServerConfig = {
   recordingStartCommand: string | null;
   recordingStopCommand: string | null;
   authToken: string | null;
+  corsAllowedOrigins: string[];
 };
 
 export function resolveConfig(env = process.env): BravePawsServerConfig {
@@ -96,5 +120,6 @@ export function resolveConfig(env = process.env): BravePawsServerConfig {
     recordingStartCommand: env.BRAVE_PAWS_RECORDING_START_COMMAND?.trim() || null,
     recordingStopCommand: env.BRAVE_PAWS_RECORDING_STOP_COMMAND?.trim() || null,
     authToken: env.BRAVE_PAWS_AUTH_TOKEN || null,
+    corsAllowedOrigins: parseCorsAllowedOrigins(env.BRAVE_PAWS_CORS_ALLOWED_ORIGINS),
   };
 }

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -35,6 +35,8 @@ const JSON_HEADERS = {
   'cache-control': 'no-store',
 };
 
+const CORS_ALLOWED_METHODS = 'GET,POST,PUT,OPTIONS';
+const CORS_ALLOWED_HEADERS = 'content-type,x-brave-paws-token';
 const RECORDING_STOP_REQUEST_MAX_BYTES = 512 * 1024;
 
 class JsonBodyTooLargeError extends Error {
@@ -47,6 +49,71 @@ class JsonBodyTooLargeError extends Error {
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown) {
   response.writeHead(statusCode, JSON_HEADERS);
   response.end(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function appendVaryHeader(response: ServerResponse, value: string) {
+  const existing = response.getHeader('vary');
+  const entries = new Set(
+    String(existing || '')
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+  entries.add(value);
+  response.setHeader('vary', Array.from(entries).join(', '));
+}
+
+function getAllowedCorsOrigin(request: IncomingMessage, config: BravePawsServerConfig): string | null {
+  const requestOrigin = request.headers.origin;
+  if (typeof requestOrigin !== 'string' || !requestOrigin) {
+    return null;
+  }
+
+  return config.corsAllowedOrigins.includes(requestOrigin) ? requestOrigin : null;
+}
+
+function applyCorsHeaders(response: ServerResponse, request: IncomingMessage, config: BravePawsServerConfig): boolean {
+  const allowedOrigin = getAllowedCorsOrigin(request, config);
+  if (!allowedOrigin) {
+    return false;
+  }
+
+  response.setHeader('access-control-allow-origin', allowedOrigin);
+  response.setHeader('access-control-allow-methods', CORS_ALLOWED_METHODS);
+  response.setHeader('access-control-allow-headers', CORS_ALLOWED_HEADERS);
+  appendVaryHeader(response, 'Origin');
+  return true;
+}
+
+function handleApiPreflight(request: IncomingMessage, response: ServerResponse, config: BravePawsServerConfig): boolean {
+  if (request.method !== 'OPTIONS') {
+    return false;
+  }
+
+  const requestOrigin = typeof request.headers.origin === 'string' ? request.headers.origin : null;
+  if (!requestOrigin) {
+    response.writeHead(204, {
+      'cache-control': 'no-store',
+      'access-control-allow-methods': CORS_ALLOWED_METHODS,
+      'access-control-allow-headers': CORS_ALLOWED_HEADERS,
+    });
+    response.end();
+    return true;
+  }
+
+  if (!applyCorsHeaders(response, request, config)) {
+    response.writeHead(403, {
+      'cache-control': 'no-store',
+    });
+    response.end();
+    return true;
+  }
+
+  response.writeHead(204, {
+    'cache-control': 'no-store',
+  });
+  response.end();
+  return true;
 }
 
 function sendText(response: ServerResponse, statusCode: number, body: string, contentType = 'text/plain; charset=utf-8') {
@@ -912,6 +979,11 @@ export function createBravePawsServer(config = resolveConfig()) {
       }
 
       if (pathname.startsWith(config.apiBasePath)) {
+        if (handleApiPreflight(request, response, config)) {
+          return;
+        }
+
+        applyCorsHeaders(response, request, config);
         await handleApiRequest(request, response, pathname, config, cameraStreamingController, sessionRecordingController);
         return;
       }

--- a/apps/brave-paws-server/tests/cameraControl.test.ts
+++ b/apps/brave-paws-server/tests/cameraControl.test.ts
@@ -30,7 +30,14 @@ function makeConfig(overrides: Partial<BravePawsServerConfig> = {}): BravePawsSe
     cameraControlStatusCommand: null,
     cameraControlEnableCommand: null,
     cameraControlDisableCommand: null,
+    recordingProvider: 'none',
+    recordingLabel: 'Session recording',
+    recordingStatusCommand: null,
+    recordingStartCommand: null,
+    recordingStopCommand: null,
     authToken: null,
+    corsAllowedOrigins: [],
+    recordingsDir: '/tmp/data/recordings',
     ...overrides,
   };
 }

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -100,6 +100,7 @@ async function withFixtureServer(
     recordingStartCommand: null,
     recordingStopCommand: null,
     authToken: null,
+    corsAllowedOrigins: [],
     recordingsDir: path.join(dataDir, 'recordings'),
     ...configOverrides,
   };
@@ -126,6 +127,71 @@ test('health endpoint reports session metadata without leaking server file paths
     assert.equal(body.dataFilePath, undefined);
     assert.equal(body.csvFilePath, undefined);
     assert.equal(body.clientDiagnosticsFilePath, undefined);
+  });
+});
+
+test('allowed CORS origins receive reflected headers on API responses', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await fetch(`${baseUrl}/separation/api/health`, {
+      headers: {
+        origin: 'https://harvey.cash',
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('access-control-allow-origin'), 'https://harvey.cash');
+    assert.equal(response.headers.get('access-control-allow-methods'), 'GET,POST,PUT,OPTIONS');
+    assert.equal(response.headers.get('access-control-allow-headers'), 'content-type,x-brave-paws-token');
+    assert.match(response.headers.get('vary') || '', /Origin/);
+  }, {
+    corsAllowedOrigins: ['https://harvey.cash'],
+  });
+});
+
+test('API OPTIONS preflight succeeds for allowed origins on sync routes', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    for (const requestPath of ['/separation/api/sync/pull', '/separation/api/sync/push']) {
+      const response = await fetch(`${baseUrl}${requestPath}`, {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://harvey.cash',
+          'access-control-request-method': 'POST',
+          'access-control-request-headers': 'content-type',
+        },
+      });
+
+      assert.equal(response.status, 204);
+      assert.equal(response.headers.get('access-control-allow-origin'), 'https://harvey.cash');
+      assert.equal(response.headers.get('access-control-allow-methods'), 'GET,POST,PUT,OPTIONS');
+      assert.equal(response.headers.get('access-control-allow-headers'), 'content-type,x-brave-paws-token');
+    }
+  }, {
+    corsAllowedOrigins: ['https://harvey.cash'],
+  });
+});
+
+test('disallowed origins do not receive permissive CORS headers', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await fetch(`${baseUrl}/separation/api/health`, {
+      headers: {
+        origin: 'https://evil.example',
+      },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('access-control-allow-origin'), null);
+
+    const preflight = await fetch(`${baseUrl}/separation/api/sync/push`, {
+      method: 'OPTIONS',
+      headers: {
+        origin: 'https://evil.example',
+        'access-control-request-method': 'POST',
+        'access-control-request-headers': 'content-type',
+      },
+    });
+    assert.equal(preflight.status, 403);
+    assert.equal(preflight.headers.get('access-control-allow-origin'), null);
+  }, {
+    corsAllowedOrigins: ['https://harvey.cash'],
   });
 });
 
@@ -712,7 +778,14 @@ test('client diagnostics endpoint requires auth when a token is configured', asy
     cameraControlStatusCommand: null,
     cameraControlEnableCommand: null,
     cameraControlDisableCommand: null,
+    recordingProvider: 'none',
+    recordingLabel: 'Session recording',
+    recordingStatusCommand: null,
+    recordingStartCommand: null,
+    recordingStopCommand: null,
     authToken: 'secret-token',
+    corsAllowedOrigins: [],
+    recordingsDir: path.join(dataDir, 'recordings'),
   };
 
   const server = createBravePawsServer(config);
@@ -844,7 +917,19 @@ test('pairing broker creates one-time pairing URLs and consumes them once', asyn
     pairingStoreFilePath: path.join(dataDir, 'pairings.json'),
     pairingEnabled: true,
     cameraUpstreamBaseUrl: `${upstreamBaseUrl}/`,
+    cameraControlProvider: 'none',
+    cameraControlLabel: 'Camera streaming',
+    cameraControlStatusCommand: null,
+    cameraControlEnableCommand: null,
+    cameraControlDisableCommand: null,
+    recordingProvider: 'none',
+    recordingLabel: 'Session recording',
+    recordingStatusCommand: null,
+    recordingStartCommand: null,
+    recordingStopCommand: null,
     authToken: 'secret-token',
+    corsAllowedOrigins: [],
+    recordingsDir: path.join(dataDir, 'recordings'),
   };
 
   const server = createBravePawsServer(config);


### PR DESCRIPTION
## Summary
- add a runtime-configurable backend root URL for Brave Paws static frontend deployments
- derive the API base and suggested camera link from the saved backend root while preserving same-origin staging defaults
- add server-side CORS allowlist and OPTIONS preflight support for cross-origin static frontend access

## Testing
- npm run app:test -- --test-name-pattern='runtime backend|backend connection|camera link|pairing token'
- npm run app:lint
- npm run server:test
- npm run server:lint
- npm run build