### PR TITLE
feat: automate QUANTUM staging refresh and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,16 @@ apps/
 
 ## Docs
 
+Active/current docs:
+
 - Local Tailnet deployment and QUANTUM staging automation: [docs/quantum-local-tailnet.md](docs/quantum-local-tailnet.md)
 - App workspace notes: [apps/brave-paws-app/README.md](apps/brave-paws-app/README.md)
 - Server workspace notes: [apps/brave-paws-server/README.md](apps/brave-paws-server/README.md)
+
+Historical context:
+
+- `docs/plans/` contains planning and implementation-brief docs kept for rationale and project history. Prefer the docs above for current operational behavior.
+- checklist-style docs under `docs/` are usually point-in-time implementation records rather than ongoing runbooks.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ apps/
 
 ## Docs
 
-- Local Tailnet deployment: [docs/quantum-local-tailnet.md](docs/quantum-local-tailnet.md)
+- Local Tailnet deployment and QUANTUM staging automation: [docs/quantum-local-tailnet.md](docs/quantum-local-tailnet.md)
 - App workspace notes: [apps/brave-paws-app/README.md](apps/brave-paws-app/README.md)
 - Server workspace notes: [apps/brave-paws-server/README.md](apps/brave-paws-server/README.md)
 
@@ -57,4 +57,4 @@ apps/
 - Canonical synced data can live on the self-hosted server while public bundles stay free of private camera origins.
 - Pairing records reject credential-bearing camera URLs so secrets do not leak into stored broker state or client responses.
 - Public CD remains `main`-only; feature branches get CI without triggering deploy.
-- QUANTUM staging is separate from public CD: `deploy/scripts/install-brave-paws-staging-automation.sh` installs a timer-driven local staging refresh that rebuilds from the local dev repo's latest committed HEAD into `/mnt/q/repos/separation-tracker-staging/` and then restarts `brave-paws.service`.
+- QUANTUM staging is separate from public CD: `deploy/scripts/install-brave-paws-staging-automation.sh` installs a timer-driven local staging refresh that rebuilds from the local dev repo's latest committed HEAD into `/mnt/q/repos/separation-tracker-staging/`, refreshes the canonical service unit, restarts `brave-paws.service`, and verifies health/capabilities.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ apps/
 - Canonical synced data can live on the self-hosted server while public bundles stay free of private camera origins.
 - Pairing records reject credential-bearing camera URLs so secrets do not leak into stored broker state or client responses.
 - Public CD remains `main`-only; feature branches get CI without triggering deploy.
+- QUANTUM staging is separate from public CD: `deploy/scripts/install-brave-paws-staging-automation.sh` installs a timer-driven local staging refresh that rebuilds from the local dev repo's latest committed HEAD into `/mnt/q/repos/separation-tracker-staging/` and then restarts `brave-paws.service`.

--- a/apps/brave-paws-app/.env.example
+++ b/apps/brave-paws-app/.env.example
@@ -4,6 +4,7 @@ VITE_BRAVE_PAWS_PUBLIC_BASE_URL="https://brave-paws.example/separation/"
 VITE_BRAVE_PAWS_APP_URL="https://brave-paws.example/separation/app/"
 VITE_BRAVE_PAWS_API_BASE_URL="https://brave-paws.example/separation/api/"
 VITE_BRAVE_PAWS_DEFAULT_CAMERA_URL="https://brave-paws.example/separation/camera/live.stream/"
+VITE_BRAVE_PAWS_BACKEND_ROOT_URL="https://quantum.tail080401.ts.net:7447"
 
 # Public deployments should not ship private camera origins directly.
 # Prefer one-time pairing links or a same-origin proxy path.

--- a/apps/brave-paws-app/README.md
+++ b/apps/brave-paws-app/README.md
@@ -33,12 +33,21 @@ Copy `.env.example` to `.env.local` and set values as needed.
 | `VITE_BRAVE_PAWS_APP_URL` | No | Canonical app URL for pairing links and stream QR links. |
 | `VITE_BRAVE_PAWS_API_BASE_URL` | No | API base URL, typically `/separation/api/`. |
 | `VITE_BRAVE_PAWS_DEFAULT_CAMERA_URL` | No | Optional suggested same-origin camera stream URL shown by the quick-start button. |
+| `VITE_BRAVE_PAWS_BACKEND_ROOT_URL` | No | Optional deployment-time backend root override. The app derives `/separation/api/` and the suggested camera link from this root when it is set. |
 
 ## Related Docs
 
 - Training-method background: [INFO.md](INFO.md)
 - Repo overview and workspace commands: [../../README.md](../../README.md)
 - Private-network deployment: [../../docs/quantum-local-tailnet.md](../../docs/quantum-local-tailnet.md)
+
+## Runtime backend override
+
+Brave Paws also supports a browser-local backend override flow for separately hosted frontends.
+
+- Users can enter a backend root such as `https://quantum.tail080401.ts.net:7447` in the in-app connection settings.
+- The app then derives the API base and suggested camera link from that root and stores the normalized value in browser storage.
+- Hosted/public frontends still need the target backend to allow their origin over CORS for the health test and subsequent API calls to succeed.
 
 ## Session Status Tracking
 

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -1,6 +1,6 @@
 # Brave Paws Server
 
-Brave Paws Server is the local-first backend for Brave Paws v0.2.2.
+Brave Paws Server is the local-first backend for Brave Paws v0.2.
 
 It serves three things from one localhost process:
 
@@ -25,6 +25,7 @@ It serves three things from one localhost process:
 | `BRAVE_PAWS_HOST` | `127.0.0.1` | Bind host for the local server |
 | `BRAVE_PAWS_PORT` | `4310` | Bind port for the local server |
 | `BRAVE_PAWS_PUBLIC_BASE_URL` | unset | Canonical external base URL used for logs, pairing URLs, and deployment docs |
+| `BRAVE_PAWS_CORS_ALLOWED_ORIGINS` | unset | Comma-separated origin allowlist for cross-origin browser access to the API (for example `https://harvey.cash,https://www.harvey.cash`) |
 | `BRAVE_PAWS_DATA_DIR` | `var/brave-paws` in the repo | Session storage directory (live QUANTUM deploy uses `/mnt/q/fermi/brave-paws/data`) |
 | `BRAVE_PAWS_AUTH_TOKEN` | unset | Token expected in `x-brave-paws-token` for write requests; required before the HTTP pairing-creation endpoint will mint links |
 | `BRAVE_PAWS_ENABLE_PAIRING` | `false` | Enables the opaque one-time pairing broker |
@@ -60,6 +61,19 @@ When pairing is enabled, opaque one-time camera pairing records are stored separ
 - Absolute `pairingUrl` values are only returned when `BRAVE_PAWS_PUBLIC_BASE_URL` is configured. Otherwise the server can still mint tokens, but callers must construct the final browser URL themselves.
 - Camera URLs with embedded credentials are rejected so secrets do not land in `pairings.json` or pairing responses.
 
+## API summary
+
+Core endpoints:
+
+- `GET /separation/api/health`
+- `GET /separation/api/sessions`
+- `GET /separation/api/sessions/:id`
+- `POST /separation/api/sessions`
+- `PUT /separation/api/sessions/:id`
+- `POST /separation/api/sync/pull`
+- `POST /separation/api/sync/push`
+- `POST /separation/api/client-diagnostics`
+
 ## Camera streaming capability API
 
 Brave Paws exposes a backend capability contract for camera streaming control:
@@ -70,7 +84,7 @@ Brave Paws exposes a backend capability contract for camera streaming control:
 
 The built-in `command` provider is intentionally generic: the server only knows how to run configured shell commands and interpret the returned enabled/disabled state. That keeps the API backend-agnostic so a future provider can control something other than picam without changing the app contract.
 
-On QUANTUM, that generic contract is wired to Harvey's existing picam privacy-toggle skill through `deploy/scripts/brave-paws-picam-camera-control.sh`, which adapts the skill's `privacy_mode=...` output into the simple enabled/disabled signal expected by the API.
+On QUANTUM, that generic contract is wired to Harvey's existing picam privacy-toggle skill through `deploy/scripts/brave-paws-picam-camera-control.sh`, which adapts the skill's `privacy_mode=...` output into the simple enabled/disabled signal expected by the API. In the live staging deployment, `brave-paws.service` runs from the clean staging worktree, so the installed unit points at `/mnt/q/repos/separation-tracker-staging/deploy/scripts/...` rather than the source checkout.
 
 ## Session recording API
 
@@ -91,3 +105,13 @@ The JSON sidecar is the source of truth. It stores the finalized session snapsho
 The intended deployment model is a passive extra reader near the media source: the live RTSP publisher remains the same, the in-app HLS preview remains the same, and the Icecast audio stream remains the same. Recording should read the source RTSP feed separately and avoid inserting transcoding or buffering into the live user-facing paths.
 
 On QUANTUM, the sample wiring for this contract lives in `deploy/scripts/brave-paws-picam-recording-control.sh`. It SSHes to `picam`, starts a passive localhost RTSP reader there, transcodes recordings to a storage-friendly H.264 MP4 profile (default: 540p at 800 kbps video plus AAC audio), finalizes the capture, and places the canonical file under the Brave Paws recordings directory on QUANTUM after stop.
+
+## QUANTUM staging notes
+
+- Canonical source repo: `/mnt/q/repos/separation-tracker`
+- Dedicated clean staging worktree: `/mnt/q/repos/separation-tracker-staging`
+- Live service: `brave-paws.service`
+- Auto-refresh oneshot: `brave-paws-staging-refresh.service`
+- Auto-refresh timer: `brave-paws-staging-refresh.timer`
+- The staging refresh follows the local dev repo's latest **committed** `HEAD`; dirty uncommitted edits are intentionally skipped.
+- A healthy `brave-paws-staging-refresh.service` run normally ends as `inactive (dead)` with `status=0/SUCCESS` because it is a oneshot verification/deploy job.

--- a/deploy/scripts/brave-paws-refresh-staging.sh
+++ b/deploy/scripts/brave-paws-refresh-staging.sh
@@ -152,15 +152,26 @@ fi
 python3 - "$HEALTH_URL" "$CAPABILITIES_URL" <<'PY'
 import json
 import sys
+import time
+import urllib.error
 import urllib.request
 
 health_url, capabilities_url = sys.argv[1:3]
+last_error = None
+health = None
 
-with urllib.request.urlopen(health_url, timeout=10) as response:
-    health = json.load(response)
-
-if health.get('status') != 'ok':
-    raise SystemExit(f"health check failed: {health!r}")
+for attempt in range(1, 13):
+    try:
+        with urllib.request.urlopen(health_url, timeout=10) as response:
+            health = json.load(response)
+        if health.get('status') != 'ok':
+            raise RuntimeError(f"health check failed: {health!r}")
+        break
+    except (urllib.error.URLError, TimeoutError, RuntimeError, ConnectionError) as error:
+        last_error = error
+        time.sleep(5)
+else:
+    raise SystemExit(f"staging health check never became ready: {last_error}")
 
 with urllib.request.urlopen(capabilities_url, timeout=10) as response:
     capabilities = json.load(response)

--- a/deploy/scripts/brave-paws-refresh-staging.sh
+++ b/deploy/scripts/brave-paws-refresh-staging.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_REPO="${BRAVE_PAWS_STAGING_SOURCE_REPO:-/mnt/q/repos/separation-tracker}"
+STAGING_WORKTREE="${BRAVE_PAWS_STAGING_WORKTREE:-/mnt/q/repos/separation-tracker-staging}"
+SERVICE_NAME="${BRAVE_PAWS_STAGING_SERVICE_NAME:-brave-paws.service}"
+HEALTH_URL="${BRAVE_PAWS_STAGING_HEALTH_URL:-http://127.0.0.1:4310/separation/api/health}"
+CAPABILITIES_URL="${BRAVE_PAWS_STAGING_CAPABILITIES_URL:-http://127.0.0.1:4310/separation/api/capabilities}"
+RUN_AS_USER="${BRAVE_PAWS_STAGING_RUN_AS_USER:-harvey}"
+ALLOW_DIRTY="${BRAVE_PAWS_STAGING_ALLOW_DIRTY:-0}"
+FORCE=0
+
+log() {
+  printf '[brave-paws-staging] %s\n' "$*"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: brave-paws-refresh-staging.sh [--force]
+
+Refreshes the dedicated QUANTUM staging worktree from the local development repo's
+latest committed HEAD, rebuilds Brave Paws there, installs the canonical staging
+systemd unit from the staging worktree, restarts the live staging service, and
+verifies health/capabilities.
+
+By default, dirty uncommitted changes in the source repo are not deployed.
+Set BRAVE_PAWS_STAGING_ALLOW_DIRTY=1 to override that safeguard.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force)
+      FORCE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "This script must run as root (it installs systemd units and restarts ${SERVICE_NAME})." >&2
+  exit 1
+fi
+
+if ! command -v runuser >/dev/null 2>&1; then
+  echo "runuser is required but not available." >&2
+  exit 1
+fi
+
+if ! id "$RUN_AS_USER" >/dev/null 2>&1; then
+  echo "Configured staging user does not exist: $RUN_AS_USER" >&2
+  exit 1
+fi
+
+if [[ ! -d "$SOURCE_REPO/.git" ]]; then
+  echo "Source repo not found or not a git repo: $SOURCE_REPO" >&2
+  exit 1
+fi
+
+export SOURCE_REPO STAGING_WORKTREE FORCE ALLOW_DIRTY
+set +e
+runuser -u "$RUN_AS_USER" -- env SOURCE_REPO="$SOURCE_REPO" STAGING_WORKTREE="$STAGING_WORKTREE" FORCE="$FORCE" ALLOW_DIRTY="$ALLOW_DIRTY" bash <<'EOS'
+set -euo pipefail
+
+SOURCE_REPO="${SOURCE_REPO:?}"
+STAGING_WORKTREE="${STAGING_WORKTREE:?}"
+FORCE="${FORCE:-0}"
+ALLOW_DIRTY="${ALLOW_DIRTY:-0}"
+
+log() {
+  printf '[brave-paws-staging:user] %s\n' "$*"
+}
+
+source_status="$(git -C "$SOURCE_REPO" status --porcelain)"
+if [[ -n "$source_status" && "$ALLOW_DIRTY" != "1" ]]; then
+  log "source repo has uncommitted changes; skipping deploy until a commit exists"
+  exit 10
+fi
+
+source_rev="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+source_branch="$(git -C "$SOURCE_REPO" rev-parse --abbrev-ref HEAD)"
+current_rev=""
+if git -C "$STAGING_WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  current_rev="$(git -C "$STAGING_WORKTREE" rev-parse HEAD)"
+fi
+
+if [[ "$FORCE" != "1" && -n "$current_rev" && "$current_rev" == "$source_rev" ]]; then
+  log "staging worktree already at ${source_rev}"
+  exit 20
+fi
+
+mkdir -p "$(dirname "$STAGING_WORKTREE")"
+if ! git -C "$STAGING_WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  log "creating staging worktree at $STAGING_WORKTREE from $source_branch ($source_rev)"
+  git -C "$SOURCE_REPO" worktree add --force --detach "$STAGING_WORKTREE" "$source_rev"
+fi
+
+log "resetting staging worktree to $source_branch ($source_rev)"
+git -C "$STAGING_WORKTREE" reset --hard "$source_rev"
+git -C "$STAGING_WORKTREE" clean -fdx
+
+cd "$STAGING_WORKTREE"
+log "installing dependencies"
+npm ci
+log "building Brave Paws staging"
+npm run build
+EOS
+user_status=$?
+set -e
+
+if [[ $user_status -eq 10 ]]; then
+  log "source repo is dirty; leaving staging on the last deployed commit"
+  exit 0
+fi
+
+if [[ $user_status -ne 0 && $user_status -ne 20 ]]; then
+  exit "$user_status"
+fi
+
+UNIT_SOURCE="$STAGING_WORKTREE/deploy/systemd/brave-paws.service"
+UNIT_DEST="/etc/systemd/system/${SERVICE_NAME}"
+needs_restart=1
+
+if [[ -f "$UNIT_DEST" && -f "$UNIT_SOURCE" ]] && cmp -s "$UNIT_SOURCE" "$UNIT_DEST" && [[ $user_status -eq 20 ]]; then
+  needs_restart=0
+fi
+
+if [[ ! -f "$UNIT_SOURCE" ]]; then
+  echo "Canonical staging unit not found: $UNIT_SOURCE" >&2
+  exit 1
+fi
+
+if [[ $needs_restart -eq 1 ]]; then
+  log "installing canonical staging unit to $UNIT_DEST"
+  install -m 0644 "$UNIT_SOURCE" "$UNIT_DEST"
+  log "reloading systemd and restarting ${SERVICE_NAME}"
+  systemctl daemon-reload
+  systemctl restart "$SERVICE_NAME"
+else
+  log "no code or unit change detected; leaving ${SERVICE_NAME} running"
+fi
+
+python3 - "$HEALTH_URL" "$CAPABILITIES_URL" <<'PY'
+import json
+import sys
+import urllib.request
+
+health_url, capabilities_url = sys.argv[1:3]
+
+with urllib.request.urlopen(health_url, timeout=10) as response:
+    health = json.load(response)
+
+if health.get('status') != 'ok':
+    raise SystemExit(f"health check failed: {health!r}")
+
+with urllib.request.urlopen(capabilities_url, timeout=10) as response:
+    capabilities = json.load(response)
+
+camera = capabilities.get('cameraStreaming') or {}
+recording = capabilities.get('sessionRecording') or {}
+
+if not camera.get('supported'):
+    raise SystemExit(f"camera capability missing or unsupported: {camera!r}")
+if not recording.get('supported'):
+    raise SystemExit(f"recording capability missing or unsupported: {recording!r}")
+
+print(json.dumps({
+    'health': health.get('status'),
+    'sessionCount': health.get('sessionCount'),
+    'cameraProvider': camera.get('provider'),
+    'recordingProvider': recording.get('provider'),
+}, indent=2))
+PY
+
+log "staging refresh complete"

--- a/deploy/scripts/install-brave-paws-staging-automation.sh
+++ b/deploy/scripts/install-brave-paws-staging-automation.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+SYSTEMD_DIR="$REPO_ROOT/deploy/systemd"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run this installer as root (for example via sudo)." >&2
+  exit 1
+fi
+
+install -m 0644 "$SYSTEMD_DIR/brave-paws-staging-refresh.service" /etc/systemd/system/brave-paws-staging-refresh.service
+install -m 0644 "$SYSTEMD_DIR/brave-paws-staging-refresh.timer" /etc/systemd/system/brave-paws-staging-refresh.timer
+systemctl daemon-reload
+systemctl enable --now brave-paws-staging-refresh.timer
+systemctl start brave-paws-staging-refresh.service
+systemctl status brave-paws-staging-refresh.service --no-pager
+systemctl status brave-paws-staging-refresh.timer --no-pager

--- a/deploy/systemd/brave-paws-staging-refresh.service
+++ b/deploy/systemd/brave-paws-staging-refresh.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Refresh Brave Paws QUANTUM staging deployment
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/env bash /mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-refresh-staging.sh

--- a/deploy/systemd/brave-paws-staging-refresh.timer
+++ b/deploy/systemd/brave-paws-staging-refresh.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Poll for Brave Paws QUANTUM staging refreshes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30s
+Persistent=true
+Unit=brave-paws-staging-refresh.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/brave-paws.service
+++ b/deploy/systemd/brave-paws.service
@@ -10,7 +10,7 @@ Group=harvey
 WorkingDirectory=/mnt/q/repos/separation-tracker
 Environment=BRAVE_PAWS_HOST=127.0.0.1
 Environment=BRAVE_PAWS_PORT=4310
-Environment=BRAVE_PAWS_PUBLIC_BASE_URL=https://tailnet-host.example.ts.net:7447
+Environment=BRAVE_PAWS_PUBLIC_BASE_URL=https://quantum.tail080401.ts.net:7447
 Environment="BRAVE_PAWS_CORS_ALLOWED_ORIGINS=https://harvey.cash,https://www.harvey.cash"
 Environment="BRAVE_PAWS_DATA_DIR=/mnt/q/fermi/brave-paws/data"
 Environment=BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL=http://127.0.0.1:18888/

--- a/deploy/systemd/brave-paws.service
+++ b/deploy/systemd/brave-paws.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=simple
 User=harvey
 Group=harvey
-WorkingDirectory=/mnt/q/repos/separation-tracker
+WorkingDirectory=/mnt/q/repos/separation-tracker-staging
 Environment=BRAVE_PAWS_HOST=127.0.0.1
 Environment=BRAVE_PAWS_PORT=4310
 Environment=BRAVE_PAWS_PUBLIC_BASE_URL=https://quantum.tail080401.ts.net:7447
@@ -16,20 +16,20 @@ Environment="BRAVE_PAWS_DATA_DIR=/mnt/q/fermi/brave-paws/data"
 Environment=BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL=http://127.0.0.1:18888/
 Environment=BRAVE_PAWS_CAMERA_CONTROL_PROVIDER=command
 Environment="BRAVE_PAWS_CAMERA_CONTROL_LABEL=Picam streaming"
-Environment="BRAVE_PAWS_CAMERA_STATUS_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh status"
-Environment="BRAVE_PAWS_CAMERA_ENABLE_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh enable"
-Environment="BRAVE_PAWS_CAMERA_DISABLE_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh disable"
+Environment="BRAVE_PAWS_CAMERA_STATUS_COMMAND=/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-camera-control.sh status"
+Environment="BRAVE_PAWS_CAMERA_ENABLE_COMMAND=/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-camera-control.sh enable"
+Environment="BRAVE_PAWS_CAMERA_DISABLE_COMMAND=/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-camera-control.sh disable"
 Environment=BRAVE_PAWS_RECORDING_PROVIDER=command
 Environment="BRAVE_PAWS_RECORDING_LABEL=Session recording"
-Environment="BRAVE_PAWS_RECORDING_STATUS_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh status"
-Environment="BRAVE_PAWS_RECORDING_START_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh start"
-Environment="BRAVE_PAWS_RECORDING_STOP_COMMAND=/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-recording-control.sh stop"
+Environment="BRAVE_PAWS_RECORDING_STATUS_COMMAND=/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-recording-control.sh status"
+Environment="BRAVE_PAWS_RECORDING_START_COMMAND=/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-recording-control.sh start"
+Environment="BRAVE_PAWS_RECORDING_STOP_COMMAND=/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-recording-control.sh stop"
 Environment="BRAVE_PAWS_RECORDING_VIDEO_HEIGHT=540"
 Environment="BRAVE_PAWS_RECORDING_VIDEO_BITRATE=800k"
 Environment="BRAVE_PAWS_RECORDING_VIDEO_MAXRATE=1000k"
 Environment="BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE=1600k"
 Environment="BRAVE_PAWS_RECORDING_AUDIO_BITRATE=96k"
-ExecStart=/usr/bin/env npm --prefix /mnt/q/repos/separation-tracker run server:start
+ExecStart=/usr/bin/env npm --prefix /mnt/q/repos/separation-tracker-staging run server:start
 Restart=on-failure
 RestartSec=3
 

--- a/deploy/systemd/brave-paws.service
+++ b/deploy/systemd/brave-paws.service
@@ -11,6 +11,7 @@ WorkingDirectory=/mnt/q/repos/separation-tracker
 Environment=BRAVE_PAWS_HOST=127.0.0.1
 Environment=BRAVE_PAWS_PORT=4310
 Environment=BRAVE_PAWS_PUBLIC_BASE_URL=https://tailnet-host.example.ts.net:7447
+Environment="BRAVE_PAWS_CORS_ALLOWED_ORIGINS=https://harvey.cash,https://www.harvey.cash"
 Environment="BRAVE_PAWS_DATA_DIR=/mnt/q/fermi/brave-paws/data"
 Environment=BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL=http://127.0.0.1:18888/
 Environment=BRAVE_PAWS_CAMERA_CONTROL_PROVIDER=command

--- a/docs/2026-05-10-recording-metadata-v1-checklist.md
+++ b/docs/2026-05-10-recording-metadata-v1-checklist.md
@@ -1,5 +1,11 @@
 # Brave Paws recording metadata v1 checklist
 
+Status: completed historical implementation checklist
+
+> Historical note: this is a completed point-in-time checklist for the recording metadata v1 slice.
+> Keep it as an audit trail for what shipped and where the smoke-test artifacts landed, not as an active runbook.
+> For current recording behavior and server capability docs, prefer `../apps/brave-paws-server/README.md` and `./quantum-local-tailnet.md`.
+
 - [x] Inspect current app/server/deploy recording flow and choose the least-fragile insertion points.
 - [x] Add app-side runtime timeline event capture for active sessions, including actual step/session transitions.
 - [x] Extend recording API payloads/contracts so stop/finalization receives the session snapshot + timeline metadata.

--- a/docs/plans/2026-05-03-brave-paws-pairing-slice.md
+++ b/docs/plans/2026-05-03-brave-paws-pairing-slice.md
@@ -1,5 +1,14 @@
 # Brave Paws pairing slice — implementation plan
 
+Status: historical implementation slice note
+
+> Historical note: this doc captures the original small-slice plan for adding opaque pairing links.
+> Keep it as rationale/history; for current app/server behavior prefer:
+> - `../../apps/brave-paws-app/README.md`
+> - `../../apps/brave-paws-server/README.md`
+>
+> The pairing capability described here has since been implemented, so this file should be read as a design snapshot rather than an active task list.
+
 ## Current state
 - The app already supports deep links that embed the raw `cameraUrl` in the query string and then caches the chosen stream in browser storage.
 - Runtime defaults fall back to same-origin paths, but the app copy/examples still assume a QUANTUM-specific shortcut and direct stream URL.

--- a/docs/plans/2026-05-03-brave-paws-v0.2-local-tailnet-executive-plan.md
+++ b/docs/plans/2026-05-03-brave-paws-v0.2-local-tailnet-executive-plan.md
@@ -3,7 +3,16 @@
 Date: 2026-05-03
 Owner: Harvey + Quantum
 Repo: `Q:/repos/separation-tracker`
-Status: proposed execution plan / handoff brief
+Status: historical execution plan / rationale note
+
+> Historical note: this document is preserved mainly as design rationale and a snapshot of the intended migration path on 2026-05-03.
+> For current operational behavior, deployment details, and QUANTUM staging automation, prefer:
+> - `../../README.md`
+> - `../quantum-local-tailnet.md`
+> - `../../apps/brave-paws-app/README.md`
+> - `../../apps/brave-paws-server/README.md`
+>
+> Some example hosts/paths below (such as `tailnet-host.example.ts.net`) are intentionally generic historical examples, not the current literal QUANTUM deployment values.
 
 ## Executive summary
 

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -32,16 +32,21 @@ Default bind:
 
 ## Environment variables
 
-| Variable | Example |
+| Variable | Current QUANTUM staging value |
 | --- | --- |
-| `BRAVE_PAWS_PUBLIC_BASE_URL` | `https://tailnet-host.example.ts.net` |
+| `BRAVE_PAWS_PUBLIC_BASE_URL` | `https://quantum.tail080401.ts.net:7447` |
+| `BRAVE_PAWS_CORS_ALLOWED_ORIGINS` | `https://harvey.cash,https://www.harvey.cash` |
 | `BRAVE_PAWS_DATA_DIR` | `/mnt/q/fermi/brave-paws/data` |
 | `BRAVE_PAWS_AUTH_TOKEN` | `replace-with-long-random-secret-before-enabling-pairing` |
 | `BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL` | `http://127.0.0.1:18888/` |
 | `BRAVE_PAWS_CAMERA_CONTROL_PROVIDER` | `command` |
-| `BRAVE_PAWS_CAMERA_STATUS_COMMAND` | `/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh status` |
-| `BRAVE_PAWS_CAMERA_ENABLE_COMMAND` | `/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh enable` |
-| `BRAVE_PAWS_CAMERA_DISABLE_COMMAND` | `/mnt/q/repos/separation-tracker/deploy/scripts/brave-paws-picam-camera-control.sh disable` |
+| `BRAVE_PAWS_CAMERA_STATUS_COMMAND` | `/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-camera-control.sh status` |
+| `BRAVE_PAWS_CAMERA_ENABLE_COMMAND` | `/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-camera-control.sh enable` |
+| `BRAVE_PAWS_CAMERA_DISABLE_COMMAND` | `/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-camera-control.sh disable` |
+| `BRAVE_PAWS_RECORDING_PROVIDER` | `command` |
+| `BRAVE_PAWS_RECORDING_STATUS_COMMAND` | `/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-recording-control.sh status` |
+| `BRAVE_PAWS_RECORDING_START_COMMAND` | `/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-recording-control.sh start` |
+| `BRAVE_PAWS_RECORDING_STOP_COMMAND` | `/mnt/q/repos/separation-tracker-staging/deploy/scripts/brave-paws-picam-recording-control.sh stop` |
 
 ## Session storage
 
@@ -103,10 +108,17 @@ systemctl status brave-paws-staging-refresh.service --no-pager
 journalctl -u brave-paws-staging-refresh.service -n 100 --no-pager
 ```
 
+Expected refresh-service behavior:
+
+- `brave-paws-staging-refresh.service` is a `Type=oneshot` job, so a healthy run normally ends as `inactive (dead)` with `status=0/SUCCESS` after finishing.
+- The refresh script includes a bounded readiness retry loop after restarting `brave-paws.service`, so a brief server startup delay should no longer cause a false failed deploy.
+
 ## Notes
 
 - The camera path is a same-origin proxy in front of picam / MediaMTX, and directory-style preview URLs such as `/separation/camera/live.stream` are redirected to the working trailing-slash preview page automatically.
 - `deploy/systemd/brave-paws.service` is the canonical QUANTUM staging unit, but the live copy should now be refreshed automatically by `brave-paws-staging-refresh.service` instead of hand-editing `/etc/systemd/system/brave-paws.service`.
 - QUANTUM's deployment now wires the generic camera-streaming capability API to the existing OpenClaw picam privacy-toggle skill through `deploy/scripts/brave-paws-picam-camera-control.sh`, so the Brave Paws dashboard toggle and session lifecycle automation drive the same underlying picam enable/disable behavior as the assistant skill.
+- QUANTUM's deployment also wires the generic recording capability API to `deploy/scripts/brave-paws-picam-recording-control.sh`, so the app footer/active-session recording controls reflect the same backend capability contract used in tests.
+- If the hosted `harvey.cash` frontend cannot connect to the Tailnet backend root, check CORS first: the QUANTUM backend must include `BRAVE_PAWS_CORS_ALLOWED_ORIGINS=https://harvey.cash,https://www.harvey.cash` and `/separation/api/capabilities` should report both `cameraStreaming.provider = "command"` and `sessionRecording.provider = "command"`.
 - If you enable pairing, also set `BRAVE_PAWS_AUTH_TOKEN`; otherwise the HTTP pairing-creation endpoint stays disabled on purpose and only the local CLI can mint tokens.
 - Local browser persistence still exists in the app; QUANTUM hydrates on open and automatically pushes changes back to the inspectable QUANTUM data folder.

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -13,10 +13,10 @@ The intended public-facing origin for v0.2 is Tailnet-only.
 
 If `:443` is already occupied by public Funnel-backed routes on QUANTUM, expose Brave Paws on a dedicated Tailnet-only HTTPS port instead. The current live deployment target is:
 
-- `https://tailnet-host.example.ts.net:7447/separation/`
-- `https://tailnet-host.example.ts.net:7447/separation/app/`
-- `https://tailnet-host.example.ts.net:7447/separation/api/health`
-- `https://tailnet-host.example.ts.net:7447/separation/camera/live.stream/`
+- `https://quantum.tail080401.ts.net:7447/separation/`
+- `https://quantum.tail080401.ts.net:7447/separation/app/`
+- `https://quantum.tail080401.ts.net:7447/separation/api/health`
+- `https://quantum.tail080401.ts.net:7447/separation/camera/live.stream/`
 
 ## Local build and run
 
@@ -67,18 +67,46 @@ If Harvey drops a fresher `brave_paws_sessions.csv` into the data folder, the se
 1. Build the repo: `npm run build`
 2. Start locally: `npm run server:start`
 3. Verify local routes with curl or a browser
-4. Install `deploy/systemd/brave-paws.service`
+4. Install the staging automation and trigger the first refresh
    ```bash
-   sudo install -m 0644 /mnt/q/repos/separation-tracker/deploy/systemd/brave-paws.service /etc/systemd/system/brave-paws.service
-   sudo systemctl daemon-reload
-   sudo systemctl restart brave-paws.service
+   sudo /mnt/q/repos/separation-tracker/deploy/scripts/install-brave-paws-staging-automation.sh
    ```
 5. Expose the server through Tailscale Serve so `/separation/...` stays Tailnet-only
+
+## Automated QUANTUM staging refresh
+
+QUANTUM staging is meant to follow the local development repo's latest committed HEAD automatically, without hand-editing `/etc/systemd/system/brave-paws.service`.
+
+The automation works like this:
+
+- source repo: `/mnt/q/repos/separation-tracker`
+- clean staging worktree: `/mnt/q/repos/separation-tracker-staging`
+- live systemd unit: `/etc/systemd/system/brave-paws.service`
+- refresh timer: `brave-paws-staging-refresh.timer`
+- refresh job: `brave-paws-staging-refresh.service`
+
+On each refresh, the script:
+
+1. checks whether the source repo has a new committed HEAD
+2. skips deployment if the source repo is dirty, so staging only follows committed states
+3. resets the dedicated staging worktree to that committed revision
+4. runs `npm ci` and `npm run build` in the staging worktree
+5. installs the canonical `deploy/systemd/brave-paws.service` from the staging worktree into `/etc/systemd/system/`
+6. restarts `brave-paws.service`
+7. verifies `/separation/api/health` and `/separation/api/capabilities`
+
+Manual checks:
+
+```bash
+systemctl status brave-paws-staging-refresh.timer --no-pager
+systemctl status brave-paws-staging-refresh.service --no-pager
+journalctl -u brave-paws-staging-refresh.service -n 100 --no-pager
+```
 
 ## Notes
 
 - The camera path is a same-origin proxy in front of picam / MediaMTX, and directory-style preview URLs such as `/separation/camera/live.stream` are redirected to the working trailing-slash preview page automatically.
-- `deploy/systemd/brave-paws.service` is the canonical QUANTUM staging unit; update `/etc/systemd/system/brave-paws.service` from that repo copy verbatim instead of hand-editing the live unit.
+- `deploy/systemd/brave-paws.service` is the canonical QUANTUM staging unit, but the live copy should now be refreshed automatically by `brave-paws-staging-refresh.service` instead of hand-editing `/etc/systemd/system/brave-paws.service`.
 - QUANTUM's deployment now wires the generic camera-streaming capability API to the existing OpenClaw picam privacy-toggle skill through `deploy/scripts/brave-paws-picam-camera-control.sh`, so the Brave Paws dashboard toggle and session lifecycle automation drive the same underlying picam enable/disable behavior as the assistant skill.
 - If you enable pairing, also set `BRAVE_PAWS_AUTH_TOKEN`; otherwise the HTTP pairing-creation endpoint stays disabled on purpose and only the local CLI can mint tokens.
 - Local browser persistence still exists in the app; QUANTUM hydrates on open and automatically pushes changes back to the inspectable QUANTUM data folder.

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -68,11 +68,17 @@ If Harvey drops a fresher `brave_paws_sessions.csv` into the data folder, the se
 2. Start locally: `npm run server:start`
 3. Verify local routes with curl or a browser
 4. Install `deploy/systemd/brave-paws.service`
+   ```bash
+   sudo install -m 0644 /mnt/q/repos/separation-tracker/deploy/systemd/brave-paws.service /etc/systemd/system/brave-paws.service
+   sudo systemctl daemon-reload
+   sudo systemctl restart brave-paws.service
+   ```
 5. Expose the server through Tailscale Serve so `/separation/...` stays Tailnet-only
 
 ## Notes
 
 - The camera path is a same-origin proxy in front of picam / MediaMTX, and directory-style preview URLs such as `/separation/camera/live.stream` are redirected to the working trailing-slash preview page automatically.
+- `deploy/systemd/brave-paws.service` is the canonical QUANTUM staging unit; update `/etc/systemd/system/brave-paws.service` from that repo copy verbatim instead of hand-editing the live unit.
 - QUANTUM's deployment now wires the generic camera-streaming capability API to the existing OpenClaw picam privacy-toggle skill through `deploy/scripts/brave-paws-picam-camera-control.sh`, so the Brave Paws dashboard toggle and session lifecycle automation drive the same underlying picam enable/disable behavior as the assistant skill.
 - If you enable pairing, also set `BRAVE_PAWS_AUTH_TOKEN`; otherwise the HTTP pairing-creation endpoint stays disabled on purpose and only the local CLI can mint tokens.
 - Local browser persistence still exists in the app; QUANTUM hydrates on open and automatically pushes changes back to the inspectable QUANTUM data folder.


### PR DESCRIPTION
## Summary
- automate QUANTUM Brave Paws staging refreshes from the local repo's latest committed HEAD via a clean staging worktree
- make the repo systemd unit canonical and harden the refresh flow with a post-restart readiness wait
- refresh the active docs and clearly mark historical planning/checklist notes as archival context

## Included fixes
- allow the hosted `harvey.cash` frontend to reach the Tailnet backend via `BRAVE_PAWS_CORS_ALLOWED_ORIGINS`
- wire session recording capability into the QUANTUM staging unit so the backend reports recording support correctly
- point the live staging service at `/mnt/q/repos/separation-tracker-staging` instead of the actively edited source checkout

## Validation
- `npm test`
- staging worktree build at `/mnt/q/repos/separation-tracker-staging` (`npm ci && npm run build`)
- live QUANTUM verification after install: staging refresh service exits successfully and `/separation/api/health` plus `/separation/api/capabilities` report healthy camera + recording providers
