### PR TITLE
fix: restore automatic picam toggling on session start/end

### DIFF
--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -135,7 +135,7 @@ export default function App() {
     }).catch(() => {
       // Camera control is best-effort; leave the pending state so a later refresh can retry.
     });
-  }, [cameraStreamingControl.capability.canSetEnabled, cameraStreamingControl.setEnabled]);
+  }, [activeSession, currentView, cameraStreamingControl.capability.canSetEnabled, cameraStreamingControl.setEnabled]);
 
   const handleStartNew = () => {
     let initialSteps = DEFAULT_STEPS;

--- a/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
+++ b/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
@@ -12,6 +12,7 @@ test('App wires camera streaming control into the dashboard and active session l
   assert.match(app, /pendingSessionCameraStateRef\.current = true/);
   assert.match(app, /pendingSessionCameraStateRef\.current = false/);
   assert.match(app, /setEnabled\(pendingState, \{ silent: true \}\)/);
+  assert.match(app, /\}, \[activeSession, currentView, cameraStreamingControl\.capability\.canSetEnabled, cameraStreamingControl\.setEnabled\]\);/);
 });
 
 


### PR DESCRIPTION
## Summary

Restore Brave Paws' automatic picam privacy toggle when entering and leaving an active session.

## Changes

- rerun the queued camera enable/disable effect when `activeSession` or `currentView` changes
- keep the existing best-effort retry behaviour intact
- add a regression assertion covering the updated effect dependency list

## Testing

- `npm run app:test`
- `npm run app:lint`
- `npm run app:build`

## Notes

I cut this PR from `main` and cherry-picked only the session camera automation fix so it stays clean and avoids dragging the broader `feature/brave-paws-v0.2` branch history back into review.
