### PR TITLE
Fix Brave Paws session edit date preservation

### DIFF
--- a/apps/brave-paws-app/src/components/SessionEditModal.tsx
+++ b/apps/brave-paws-app/src/components/SessionEditModal.tsx
@@ -5,6 +5,7 @@ import { format } from 'date-fns';
 import { formatDuration } from '../utils/format';
 import { DurationInput } from './DurationInput';
 import { getSessionStatusLabel, getStatusButtonClasses, getStepStatusLabel } from '../utils/sessionStatus';
+import { applySessionCalendarDate } from '../utils/sessionDate';
 
 export function SessionEditModal({ 
   session, 
@@ -57,7 +58,7 @@ export function SessionEditModal({
   const handleSaveClick = () => {
     onSave({ 
       ...session, 
-      date: new Date(date).toISOString(),
+      date: applySessionCalendarDate(session.date, date),
       anxietyScore, 
       exercisedLevel,
       anyoneHome,

--- a/apps/brave-paws-app/src/components/SessionView.tsx
+++ b/apps/brave-paws-app/src/components/SessionView.tsx
@@ -22,6 +22,7 @@ import {
   getStepStatusBadgeClasses,
   getStepStatusLabel,
 } from '../utils/sessionStatus';
+import { applySessionCalendarDate } from '../utils/sessionDate';
 
 type Props = {
   session: Session;
@@ -95,7 +96,7 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave, 
   const handleSave = () => {
     onSave({
       ...session,
-      date: new Date(draftDate).toISOString(),
+      date: applySessionCalendarDate(session.date, draftDate),
       anxietyScore: draftAnxietyScore,
       exercisedLevel: draftExercisedLevel,
       anyoneHome: draftAnyoneHome,

--- a/apps/brave-paws-app/src/utils/sessionDate.ts
+++ b/apps/brave-paws-app/src/utils/sessionDate.ts
@@ -1,0 +1,20 @@
+export function applySessionCalendarDate(previousIso: string, nextDateInput: string): string {
+  const [yearStr, monthStr, dayStr] = nextDateInput.split('-');
+  const year = Number.parseInt(yearStr ?? '', 10);
+  const monthIndex = Number.parseInt(monthStr ?? '', 10) - 1;
+  const day = Number.parseInt(dayStr ?? '', 10);
+
+  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || !Number.isInteger(day)) {
+    return previousIso;
+  }
+
+  const previous = new Date(previousIso);
+  if (Number.isNaN(previous.getTime())) {
+    const fallback = new Date(year, monthIndex, day, 12, 0, 0, 0);
+    return fallback.toISOString();
+  }
+
+  const next = new Date(previous);
+  next.setFullYear(year, monthIndex, day);
+  return next.toISOString();
+}

--- a/apps/brave-paws-app/tests/session-date.test.ts
+++ b/apps/brave-paws-app/tests/session-date.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applySessionCalendarDate } from '../src/utils/sessionDate.ts';
+
+test('applySessionCalendarDate preserves the original time when the date is unchanged', () => {
+  const original = '2026-05-13T15:37:53.790Z';
+  const updated = applySessionCalendarDate(original, '2026-05-13');
+
+  assert.equal(updated, original);
+});
+
+test('applySessionCalendarDate updates the calendar date without zeroing the time of day', () => {
+  const original = '2026-05-13T15:37:53.790Z';
+  const updated = applySessionCalendarDate(original, '2026-05-11');
+
+  assert.equal(updated, '2026-05-11T15:37:53.790Z');
+});


### PR DESCRIPTION
## Summary
- preserve the original session time-of-day when editing a session from the history modal or session details view
- avoid unintentionally rewriting edited sessions to midnight when only the calendar date picker is involved
- add focused tests for date-preserving session edits

## Why
Editing a historical session could rewrite its ISO timestamp via `new Date(yyyy-mm-dd).toISOString()`, which zeroed the time component and could shift the session's ordering in history. This made sessions appear to disappear after save when they had actually moved.

## Testing
- npm run app:test
- npm run app:lint
- npm run app:build
