### PR TITLE
Track actual step timing and regenerate recording chapters

### DIFF
--- a/apps/brave-paws-app/e2e/session-flow.spec.ts
+++ b/apps/brave-paws-app/e2e/session-flow.spec.ts
@@ -96,27 +96,28 @@ test.describe('Session flow', () => {
     await expect(page.getByRole('button', { name: 'Wrap Up Session' })).toBeVisible();
 
     const sessionElapsed = page.locator('header span.font-mono').first();
-    const stepRemaining = page.locator('div.text-8xl');
+    const stepElapsed = page.locator('div.text-8xl');
     const stepToggle = page.locator('div.flex.items-center.gap-6 > button').first();
     const elapsedAtStart = parseClock(await sessionElapsed.textContent() ?? DEFAULT_CLOCK);
 
+    await expect(page.getByText('Goal').first()).toBeVisible();
     await stepToggle.click();
     await expect.poll(async () => parseClock(await sessionElapsed.textContent() ?? DEFAULT_CLOCK)).toBeGreaterThan(elapsedAtStart);
-    await expect.poll(async () => parseClock(await stepRemaining.textContent() ?? DEFAULT_CLOCK)).toBeLessThan(30);
+    await expect.poll(async () => parseClock(await stepElapsed.textContent() ?? DEFAULT_CLOCK)).toBeGreaterThan(0);
 
     const elapsedBeforeReload = parseClock(await sessionElapsed.textContent() ?? DEFAULT_CLOCK);
-    const remainingBeforeReload = parseClock(await stepRemaining.textContent() ?? DEFAULT_CLOCK);
+    const stepElapsedBeforeReload = parseClock(await stepElapsed.textContent() ?? DEFAULT_CLOCK);
 
     await page.reload();
     await expect(page.getByRole('button', { name: 'Wrap Up Session' })).toBeVisible();
 
     const elapsedAfterReload = parseClock(await sessionElapsed.textContent() ?? DEFAULT_CLOCK);
-    const remainingAfterReload = parseClock(await stepRemaining.textContent() ?? DEFAULT_CLOCK);
+    const stepElapsedAfterReload = parseClock(await stepElapsed.textContent() ?? DEFAULT_CLOCK);
 
     expect(elapsedAfterReload).toBeGreaterThanOrEqual(elapsedBeforeReload);
-    expect(remainingAfterReload).toBeLessThanOrEqual(remainingBeforeReload);
+    expect(stepElapsedAfterReload).toBeGreaterThanOrEqual(stepElapsedBeforeReload);
 
     await expect.poll(async () => parseClock(await sessionElapsed.textContent() ?? DEFAULT_CLOCK)).toBeGreaterThan(elapsedAfterReload);
-    await expect.poll(async () => parseClock(await stepRemaining.textContent() ?? DEFAULT_CLOCK)).toBeLessThan(remainingAfterReload);
+    await expect.poll(async () => parseClock(await stepElapsed.textContent() ?? DEFAULT_CLOCK)).toBeGreaterThan(stepElapsedAfterReload);
   });
 });

--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -144,9 +144,10 @@ export default function App() {
     if (sessions.length > 0) {
       const sorted = [...sessions].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
       const lastSession = sorted[0];
-      initialSteps = lastSession.steps.map(s => ({
-        ...s,
+      initialSteps = lastSession.steps.map((step) => ({
+        ...step,
         id: crypto.randomUUID(),
+        actualDurationSeconds: null,
         status: 'pending',
       }));
     }

--- a/apps/brave-paws-app/src/components/ActiveSession.tsx
+++ b/apps/brave-paws-app/src/components/ActiveSession.tsx
@@ -4,7 +4,7 @@ import { Play, Pause, CheckCircle2, Circle, Flag, X, Heart, VideoOff, RotateCcw,
 import { formatTime, formatDuration } from '../utils/format';
 import { buildCameraStreamUrl, isCameraUrlValid } from '../utils/cameraUrl';
 import { CameraLinkInput } from './CameraLinkInput';
-import { TimerClock, getElapsedSeconds, getRemainingSeconds, pauseTimer, startTimer } from '../utils/timer';
+import { TimerClock, getElapsedSeconds, pauseTimer, startTimer } from '../utils/timer';
 import { ActiveSessionState } from '../utils/activeSessionStorage';
 import { reportClientDiagnostic } from '../utils/clientDiagnostics';
 import {
@@ -55,25 +55,11 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
   const [sessionElapsed, setSessionElapsed] = useState(() => getElapsedSeconds(initialSessionClock));
   const [sessionClock, setSessionClock] = useState<TimerClock>(() => initialSessionClock);
 
-  // Current step countdown
+  // Current step stopwatch
   const [currentStepIndex, setCurrentStepIndex] = useState(restoredState?.currentStepIndex ?? 0);
   const [isStepRunning, setIsStepRunning] = useState(restoredState?.isStepRunning ?? false);
   const [stepClock, setStepClock] = useState<TimerClock>(() => initialStepClock);
-  const [stepRemaining, setStepRemaining] = useState(() => {
-    const restoredSession = restoredState?.session ?? initialSession;
-    const restoredIndex = restoredState?.currentStepIndex ?? 0;
-    const currentStep = restoredSession.steps[restoredIndex];
-
-    if (!currentStep) {
-      return 0;
-    }
-
-    if (!restoredState) {
-      return currentStep.durationSeconds;
-    }
-
-    return getRemainingSeconds(currentStep.durationSeconds, restoredState.stepClock);
-  });
+  const [stepElapsed, setStepElapsed] = useState(() => getElapsedSeconds(initialStepClock));
   const [timelineEvents, setTimelineEvents] = useState<SessionTimelineEvent[]>(restoredState?.timelineEvents ?? []);
   const [previewReloadToken, setPreviewReloadToken] = useState(0);
   const [previewStatus, setPreviewStatus] = useState<'idle' | 'loading' | 'live' | 'degraded' | 'disconnected'>('idle');
@@ -174,16 +160,21 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
 
   const finalizeStep = useCallback((index: number, status: StepStatus, now = Date.now()) => {
     const pausedStepClock = pauseTimer(stepClockRef.current, now);
+    const actualDurationSeconds = getElapsedSeconds(pausedStepClock, now);
     const nextStepClock = { startedAt: null, accumulatedMs: 0 };
     const currentSession = sessionRef.current;
     const newSteps = [...currentSession.steps];
-    newSteps[index] = { ...newSteps[index], status };
+    newSteps[index] = {
+      ...newSteps[index],
+      status,
+      actualDurationSeconds,
+    };
     const updatedSession = { ...currentSession, steps: newSteps };
 
     sessionRef.current = updatedSession;
     setSession(updatedSession);
     updateStepClock(nextStepClock);
-    setStepRemaining(0);
+    setStepElapsed(0);
     isStepRunningRef.current = false;
     setIsStepRunning(false);
 
@@ -200,7 +191,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       const nextStepIndex = index + 1;
       currentStepIndexRef.current = nextStepIndex;
       setCurrentStepIndex(nextStepIndex);
-      setStepRemaining(updatedSession.steps[nextStepIndex]!.durationSeconds);
+      setStepElapsed(0);
       return;
     }
 
@@ -221,19 +212,14 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     });
   }, [appendTimelineEvent, updateSessionClock, updateStepClock]);
 
-  const syncStepRemaining = useCallback((now = Date.now()) => {
+  const syncStepElapsed = useCallback((now = Date.now()) => {
     const currentStep = sessionRef.current.steps[currentStepIndexRef.current];
     if (!currentStep) {
       return;
     }
 
-    const remaining = getRemainingSeconds(currentStep.durationSeconds, stepClockRef.current, now);
-    setStepRemaining(remaining);
-
-      if (isStepRunningRef.current && remaining === 0) {
-        finalizeStep(currentStepIndexRef.current, 'completed', now);
-      }
-  }, [finalizeStep]);
+    setStepElapsed(getElapsedSeconds(stepClockRef.current, now));
+  }, []);
 
   const applyRecordingCapability = useCallback((capability: SessionRecordingCapability) => {
     setRecordingCapability(capability);
@@ -290,27 +276,27 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     };
   }, [isSessionRunning, syncSessionElapsed]);
 
-  // Step Countdown
+  // Step Stopwatch
   useEffect(() => {
-    syncStepRemaining();
+    syncStepElapsed();
     if (!isStepRunning) {
       return;
     }
 
     const intervalId = window.setInterval(() => {
-      syncStepRemaining();
+      syncStepElapsed();
     }, 1000);
 
     return () => {
       clearInterval(intervalId);
     };
-  }, [isStepRunning, syncStepRemaining]);
+  }, [isStepRunning, syncStepElapsed]);
 
   useEffect(() => {
     const syncTimers = () => {
       const now = Date.now();
       syncSessionElapsed(now);
-      syncStepRemaining(now);
+      syncStepElapsed(now);
     };
 
     const handleVisibilityChange = () => {
@@ -328,7 +314,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       window.removeEventListener('pageshow', syncTimers);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [syncSessionElapsed, syncStepRemaining]);
+  }, [syncSessionElapsed, syncStepElapsed]);
 
   useEffect(() => {
     let isCancelled = false;
@@ -432,9 +418,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     if (isStepRunning) {
       const pausedClock = pauseTimer(stepClockRef.current, now);
       updateStepClock(pausedClock);
-      setStepRemaining(
-        getRemainingSeconds(sessionRef.current.steps[currentStepIndexRef.current]?.durationSeconds || 0, pausedClock, now)
-      );
+      setStepElapsed(getElapsedSeconds(pausedClock, now));
       isStepRunningRef.current = false;
       setIsStepRunning(false);
       appendTimelineEvent('step_paused', {
@@ -804,10 +788,14 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
                 <Heart size={14} fill="currentColor" />
                 Step {currentStepIndex + 1} of {session.steps.length}
               </div>
-              <div className="text-8xl font-mono font-light text-slate-800 tracking-tighter mb-12 tabular-nums">
-                {formatTime(stepRemaining)}
+              <div className="text-8xl font-mono font-light text-slate-800 tracking-tighter tabular-nums">
+                {formatTime(stepElapsed)}
               </div>
-              
+              <div className="mt-3 mb-12 text-center">
+                <div className="text-xs font-bold uppercase tracking-[0.18em] text-slate-400">Goal</div>
+                <div className="mt-1 text-sm font-medium text-slate-500">{formatDuration(currentStep.durationSeconds)}</div>
+              </div>
+
               <div className="flex items-center gap-6">
                 <button
                   onClick={handleToggleStep}
@@ -893,9 +881,12 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
                     Step {idx + 1}
                   </span>
                 </div>
-                <span className="text-slate-500 font-mono text-sm font-medium">
-                  {formatDuration(step.durationSeconds)}
-                </span>
+                <div className="text-right font-mono text-sm font-medium text-slate-500">
+                  <div>{formatDuration(step.actualDurationSeconds ?? step.durationSeconds)}</div>
+                  {step.actualDurationSeconds != null && (
+                    <div className="text-[11px] text-slate-400">Goal {formatDuration(step.durationSeconds)}</div>
+                  )}
+                </div>
               </div>
             ))}
           </div>

--- a/apps/brave-paws-app/src/components/Dashboard.tsx
+++ b/apps/brave-paws-app/src/components/Dashboard.tsx
@@ -3,7 +3,7 @@ import { formatDuration } from '../utils/format';
 import { Play, BarChart2, History, Heart, Info, Server } from 'lucide-react';
 import { format } from 'date-fns';
 import { ReactNode } from 'react';
-import { getAbortedStepCount, getCompletedStepCount } from '../utils/sessionStatus';
+import { getAbortedStepCount, getCompletedStepCount, getRecordedStepDurationSeconds } from '../utils/sessionStatus';
 
 type Props = {
   sessions: Session[];
@@ -137,7 +137,7 @@ export function Dashboard({
         ) : (
           <div className="space-y-3">
             {recentSessions.map((session) => {
-              const maxStep = Math.max(...session.steps.map(s => s.durationSeconds), 0);
+              const maxStep = Math.max(...session.steps.map((step) => getRecordedStepDurationSeconds(step)), 0);
               return (
                 <div
                   key={session.id}

--- a/apps/brave-paws-app/src/components/GraphView.tsx
+++ b/apps/brave-paws-app/src/components/GraphView.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { format } from 'date-fns';
+import { getRecordedStepDurationSeconds } from '../utils/sessionStatus';
 
 type Props = {
   sessions: Session[];
@@ -20,7 +21,7 @@ export function getGraphData(sessions: Session[]) {
   return [...sessions]
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .map((session) => {
-      const maxDuration = Math.max(0, ...session.steps.map((step) => step.durationSeconds));
+      const maxDuration = Math.max(0, ...session.steps.map((step) => getRecordedStepDurationSeconds(step)));
       return {
         date: format(new Date(session.date), 'MMM d'),
         maxDurationMinutes: parseFloat((maxDuration / 60).toFixed(2)),

--- a/apps/brave-paws-app/src/components/HistoryList.tsx
+++ b/apps/brave-paws-app/src/components/HistoryList.tsx
@@ -4,7 +4,7 @@ import { formatDuration } from '../utils/format';
 import { format } from 'date-fns';
 import { Trash2, Edit2, Plus, CalendarHeart, Download, Upload } from 'lucide-react';
 import { SessionEditModal } from './SessionEditModal';
-import { getAbortedStepCount, getCompletedStepCount, getSessionStatusLabel } from '../utils/sessionStatus';
+import { getAbortedStepCount, getCompletedStepCount, getRecordedStepDurationSeconds, getSessionStatusLabel } from '../utils/sessionStatus';
 
 export function HistoryList({ 
   sessions, 
@@ -135,7 +135,7 @@ export function HistoryList({
       ) : (
         <div className="space-y-4">
           {sortedSessions.map(session => {
-            const maxStep = Math.max(...session.steps.map(s => s.durationSeconds), 0);
+            const maxStep = Math.max(...session.steps.map((step) => getRecordedStepDurationSeconds(step)), 0);
             
             return (
               <div 

--- a/apps/brave-paws-app/src/components/SessionView.tsx
+++ b/apps/brave-paws-app/src/components/SessionView.tsx
@@ -16,6 +16,7 @@ import {
 import {
   getAbortedStepCount,
   getCompletedStepCount,
+  getRecordedStepDurationSeconds,
   getSessionStatusBadgeClasses,
   getSessionStatusLabel,
   getStatusButtonClasses,
@@ -125,6 +126,7 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave, 
     const newStep: Step = {
       id: crypto.randomUUID(),
       durationSeconds: newStepDuration,
+      actualDurationSeconds: newStepDuration,
       status: 'completed',
     };
     setDraftSteps([...draftSteps, newStep]);
@@ -144,24 +146,45 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave, 
   };
 
   const handleUpdateStepDuration = (id: string, duration: number) => {
-    setDraftSteps(draftSteps.map((s) =>
-      s.id === id ? { ...s, durationSeconds: duration } : s
-    ));
+    setDraftSteps(draftSteps.map((step) => {
+      if (step.id !== id) {
+        return step;
+      }
+
+      if (step.actualDurationSeconds != null || step.status !== 'pending') {
+        return { ...step, actualDurationSeconds: duration };
+      }
+
+      return { ...step, durationSeconds: duration };
+    }));
   };
 
   const handleUpdateStepStatus = (id: string, status: Step['status']) => {
-    setDraftSteps(draftSteps.map((step) =>
-      step.id === id ? { ...step, status } : step
-    ));
+    setDraftSteps(draftSteps.map((step) => {
+      if (step.id !== id) {
+        return step;
+      }
+
+      if (status === 'pending') {
+        return { ...step, status, actualDurationSeconds: null };
+      }
+
+      return {
+        ...step,
+        status,
+        actualDurationSeconds: step.actualDurationSeconds ?? step.durationSeconds,
+      };
+    }));
   };
 
-  const maxStep = Math.max(...session.steps.map(s => s.durationSeconds), 0);
+  const maxStep = Math.max(...session.steps.map((step) => getRecordedStepDurationSeconds(step)), 0);
   const completedSteps = getCompletedStepCount(session.steps);
   const abortedSteps = getAbortedStepCount(session.steps);
   
   const chartData = session.steps.map((step, index) => ({
     step: `Step ${index + 1}`,
-    duration: step.durationSeconds,
+    duration: getRecordedStepDurationSeconds(step),
+    goalDuration: step.durationSeconds,
     statusLabel: getStepStatusLabel(step.status),
   }));
 
@@ -301,7 +324,11 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave, 
           <div>
             <p className="text-xs text-slate-500 mb-3 font-bold uppercase tracking-widest">Steps</p>
             <div className="space-y-3 mb-4">
-              {draftSteps.map((step, index) => (
+              {draftSteps.map((step, index) => {
+                const editableDuration = step.actualDurationSeconds ?? step.durationSeconds;
+                const isEditingActualDuration = step.actualDurationSeconds != null || step.status !== 'pending';
+
+                return (
                 <div
                   key={step.id}
                   className="flex flex-wrap items-center gap-3 p-3 bg-slate-50 rounded-2xl border border-slate-100 hover:border-slate-200 transition-colors group"
@@ -310,14 +337,20 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave, 
                     <GripVertical size={20} />
                   </div>
                   <span className="font-bold text-slate-400 w-8">#{index + 1}</span>
+                  <div className="min-w-[5rem] text-[11px] font-bold uppercase tracking-wider text-slate-400">
+                    {isEditingActualDuration ? 'Actual' : 'Goal'}
+                  </div>
                   <DurationInput
-                    valueSeconds={step.durationSeconds}
+                    valueSeconds={editableDuration}
                     onChange={(duration) => handleUpdateStepDuration(step.id, duration)}
                     className="flex-1"
                   />
-                  <span className="text-slate-500 w-16 text-right text-sm font-medium">
-                    {formatDuration(step.durationSeconds)}
-                  </span>
+                  <div className="min-w-[5.5rem] text-right text-sm font-medium text-slate-500">
+                    <div>{formatDuration(editableDuration)}</div>
+                    {isEditingActualDuration && (
+                      <div className="text-[11px] text-slate-400">Goal {formatDuration(step.durationSeconds)}</div>
+                    )}
+                  </div>
                   <select
                     value={step.status}
                     onChange={(e) => handleUpdateStepStatus(step.id, e.target.value as Step['status'])}
@@ -337,7 +370,8 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave, 
                     <Trash2 size={20} />
                   </button>
                 </div>
-              ))}
+                );
+              })}
               {draftSteps.length === 0 && (
                 <div className="text-center py-6 bg-slate-50 rounded-2xl border border-dashed border-slate-200">
                   <p className="text-slate-400 font-medium text-sm">No steps recorded.</p>
@@ -522,7 +556,15 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave, 
                     padding: '12px 16px',
                     fontWeight: 500
                   }}
-                  formatter={(value: number) => [`${value} s`, 'Duration']}
+                  formatter={(value: number, _name: string, payload) => {
+                    const goalDuration = payload?.payload?.goalDuration;
+                    return [
+                      goalDuration != null && goalDuration !== value
+                        ? `${value} s actual · ${goalDuration} s goal`
+                        : `${value} s`,
+                      'Duration',
+                    ];
+                  }}
                   labelStyle={{ color: '#64748b', marginBottom: '4px' }}
                 />
                 <Line
@@ -550,7 +592,12 @@ export function SessionView({ session, allSessions, onBack, onNavigate, onSave, 
             >
               <div>
                 <p className="font-bold text-slate-800">Step {index + 1}</p>
-                <p className="text-sm text-slate-500">{formatDuration(step.durationSeconds)}</p>
+                <p className="text-sm text-slate-500">
+                  {formatDuration(getRecordedStepDurationSeconds(step))}
+                  {step.actualDurationSeconds != null && (
+                    <span className="text-slate-400"> · goal {formatDuration(step.durationSeconds)}</span>
+                  )}
+                </p>
               </div>
               <span className={`rounded-full border px-3 py-1 text-xs font-bold uppercase tracking-wider ${getStepStatusBadgeClasses(step.status)}`}>
                 {getStepStatusLabel(step.status)}

--- a/apps/brave-paws-app/src/types.ts
+++ b/apps/brave-paws-app/src/types.ts
@@ -3,6 +3,7 @@ export type StepStatus = 'pending' | 'completed' | 'aborted';
 export type Step = {
   id: string;
   durationSeconds: number;
+  actualDurationSeconds?: number | null;
   status: StepStatus;
 };
 

--- a/apps/brave-paws-app/src/utils/export.ts
+++ b/apps/brave-paws-app/src/utils/export.ts
@@ -1,7 +1,7 @@
 import { Session, SessionStatus, Step, StepStatus } from '../types';
 import { format } from 'date-fns';
 import { buildImportedSessionId } from './sessionIdentity';
-import { getAbortedStepCount, getCompletedStepCount } from './sessionStatus';
+import { getAbortedStepCount, getCompletedStepCount, getRecordedStepDurationSeconds } from './sessionStatus';
 
 const STEP_COLUMN_COUNT = 10;
 const HEADERS = [
@@ -114,10 +114,10 @@ export function generateCSVContent(sessions: Session[]): string {
     const exercisedLevel = session.exercisedLevel ?? '';
     const anyoneHome = session.anyoneHome ? escapeCSVValue(session.anyoneHome) : '';
 
-    const maxDuration = session.steps.length > 0 ? Math.max(...session.steps.map((step) => step.durationSeconds)) : 0;
+    const maxDuration = session.steps.length > 0 ? Math.max(...session.steps.map((step) => getRecordedStepDurationSeconds(step))) : 0;
 
     const stepDurations = Array.from({ length: STEP_COLUMN_COUNT }, (_, i) => {
-      return i < session.steps.length ? session.steps[i].durationSeconds : '';
+      return i < session.steps.length ? getRecordedStepDurationSeconds(session.steps[i]) : '';
     });
 
     const stepStatuses = Array.from({ length: STEP_COLUMN_COUNT }, (_, i) => {
@@ -236,6 +236,7 @@ export function parseCSV(csvContent: string): Session[] {
       status: sessionWithoutId.status,
       steps: sessionWithoutId.steps.map((step) => ({
         durationSeconds: step.durationSeconds,
+        actualDurationSeconds: step.actualDurationSeconds ?? null,
         status: step.status,
       })),
     });

--- a/apps/brave-paws-app/src/utils/sessionIdentity.ts
+++ b/apps/brave-paws-app/src/utils/sessionIdentity.ts
@@ -22,6 +22,7 @@ function buildSessionFingerprint(session: Omit<Session, 'id'> | Session): string
     status: session.status,
     steps: session.steps.map((step) => ({
       durationSeconds: step.durationSeconds,
+      actualDurationSeconds: step.actualDurationSeconds ?? null,
       status: step.status,
     })),
   });

--- a/apps/brave-paws-app/src/utils/sessionStatus.ts
+++ b/apps/brave-paws-app/src/utils/sessionStatus.ts
@@ -64,6 +64,10 @@ export function getResolvedStepCount(steps: Step[]): number {
   return steps.filter((step) => step.status !== 'pending').length;
 }
 
+export function getRecordedStepDurationSeconds(step: Step): number {
+  return step.actualDurationSeconds ?? step.durationSeconds;
+}
+
 export function normalizeStep(value: unknown): Step | null {
   if (!value || typeof value !== 'object') {
     return null;
@@ -72,6 +76,7 @@ export function normalizeStep(value: unknown): Step | null {
   const candidate = value as {
     id?: unknown;
     durationSeconds?: unknown;
+    actualDurationSeconds?: unknown;
     status?: unknown;
     completed?: unknown;
   };
@@ -85,6 +90,11 @@ export function normalizeStep(value: unknown): Step | null {
       ? Math.max(0, candidate.durationSeconds)
       : 0;
 
+  const actualDurationSeconds =
+    typeof candidate.actualDurationSeconds === 'number' && Number.isFinite(candidate.actualDurationSeconds)
+      ? Math.max(0, candidate.actualDurationSeconds)
+      : undefined;
+
   // Legacy data only stored a boolean completed flag, where false meant the step
   // had not been resolved yet. Preserve that as pending for backwards compatibility.
   const status = isStepStatus(candidate.status)
@@ -96,6 +106,7 @@ export function normalizeStep(value: unknown): Step | null {
   return {
     id: candidate.id,
     durationSeconds,
+    ...(actualDurationSeconds != null ? { actualDurationSeconds } : {}),
     status,
   };
 }

--- a/apps/brave-paws-app/src/utils/sessionSync.ts
+++ b/apps/brave-paws-app/src/utils/sessionSync.ts
@@ -7,6 +7,7 @@ function serializeStep(step: Step) {
   return {
     id: step.id,
     durationSeconds: step.durationSeconds,
+    actualDurationSeconds: step.actualDurationSeconds ?? null,
     status: step.status,
   };
 }

--- a/apps/brave-paws-server/src/csv.ts
+++ b/apps/brave-paws-server/src/csv.ts
@@ -110,10 +110,12 @@ export function generateCSVContent(sessions: Session[]): string {
     const notes = session.notes ? escapeCSVValue(session.notes) : '';
     const exercisedLevel = session.exercisedLevel ?? '';
     const anyoneHome = session.anyoneHome ? escapeCSVValue(session.anyoneHome) : '';
-    const maxDuration = session.steps.length > 0 ? Math.max(...session.steps.map((step) => step.durationSeconds)) : 0;
+    const maxDuration = session.steps.length > 0
+      ? Math.max(...session.steps.map((step) => step.actualDurationSeconds ?? step.durationSeconds))
+      : 0;
 
     const stepDurations = Array.from({ length: STEP_COLUMN_COUNT }, (_, index) => (
-      index < session.steps.length ? session.steps[index].durationSeconds : ''
+      index < session.steps.length ? (session.steps[index].actualDurationSeconds ?? session.steps[index].durationSeconds) : ''
     ));
     const stepStatuses = Array.from({ length: STEP_COLUMN_COUNT }, (_, index) => (
       index < session.steps.length ? session.steps[index].status : ''
@@ -222,6 +224,7 @@ export function parseCSV(content: string): Session[] {
       status: sessionWithoutId.status,
       steps: sessionWithoutId.steps.map((step) => ({
         durationSeconds: step.durationSeconds,
+        actualDurationSeconds: step.actualDurationSeconds ?? null,
         status: step.status,
       })),
     });

--- a/apps/brave-paws-server/src/recordingMetadata.ts
+++ b/apps/brave-paws-server/src/recordingMetadata.ts
@@ -51,6 +51,7 @@ export type BravePawsRecordingMetadataV1 = {
     steps: Array<{
       index: number;
       plannedDurationSeconds: number;
+      actualDurationSeconds: number | null;
       status: string;
     }>;
   };
@@ -158,6 +159,30 @@ function formatChapterDuration(durationSeconds: number | null): string | null {
   return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
 
+function getRecordedStepDurationSeconds(step: Session['steps'][number]): number {
+  return step.actualDurationSeconds ?? step.durationSeconds;
+}
+
+function describeSessionSnapshotStep(index: number, sessionSnapshot: Session): string | null {
+  const step = sessionSnapshot.steps[index];
+  if (!step) {
+    return null;
+  }
+
+  const actualDuration = formatChapterDuration(getRecordedStepDurationSeconds(step));
+  const stepLabel = `Step ${index + 1}${actualDuration ? ` · ${actualDuration}` : ''}`;
+
+  if (step.status === 'completed') {
+    return `${stepLabel} completed`;
+  }
+
+  if (step.status === 'aborted') {
+    return `${stepLabel} aborted`;
+  }
+
+  return stepLabel;
+}
+
 function describeTimelineState(event: SessionTimelineEvent): string {
   const stepNumber = event.currentStepIndex != null ? event.currentStepIndex + 1 : null;
   const plannedDuration = formatChapterDuration(event.stepDurationSeconds);
@@ -194,12 +219,49 @@ function clampMilliseconds(value: number, minValue: number, maxValue: number): n
 }
 
 export function deriveRecordingChapters(options: {
+  sessionSnapshot?: Session | null;
   timelineEvents: SessionTimelineEvent[];
   recordingStartedAt?: string | null;
   recordingStoppedAt?: string | null;
   recordingDurationSeconds?: number | null;
 }): RecordingMetadataChapter[] {
   const timelineEvents = normalizeTimelineEvents(options.timelineEvents);
+  const sessionSnapshot = options.sessionSnapshot ?? null;
+
+  if (sessionSnapshot?.steps.length) {
+    const snapshotChapters: RecordingMetadataChapter[] = [];
+    let cursorMs = 0;
+
+    for (let index = 0; index < sessionSnapshot.steps.length; index += 1) {
+      const step = sessionSnapshot.steps[index]!;
+      const durationSeconds = getRecordedStepDurationSeconds(step);
+      const durationMs = Math.max(0, Math.round(durationSeconds * 1000));
+      const title = describeSessionSnapshotStep(index, sessionSnapshot);
+      if (!title || durationMs <= 0) {
+        continue;
+      }
+
+      snapshotChapters.push({
+        index: snapshotChapters.length + 1,
+        title,
+        startTimeMs: cursorMs,
+        endTimeMs: cursorMs + durationMs,
+        startSeconds: Number((cursorMs / 1000).toFixed(3)),
+        endSeconds: Number(((cursorMs + durationMs) / 1000).toFixed(3)),
+        sourceEventSequence: null,
+      });
+      cursorMs += durationMs;
+    }
+
+    if (snapshotChapters.length > 0 && sessionSnapshot.steps.some((step) => step.actualDurationSeconds != null)) {
+      return snapshotChapters;
+    }
+
+    if (!timelineEvents.length && snapshotChapters.length > 0) {
+      return snapshotChapters;
+    }
+  }
+
   if (!timelineEvents.length) {
     return [];
   }
@@ -269,6 +331,21 @@ function buildMetadataRelativePath(relativeRecordingPath: string): string {
 
 function buildMetadataFilePath(config: BravePawsServerConfig, relativeRecordingPath: string): string {
   return path.join(config.recordingsDir, ...buildMetadataRelativePath(relativeRecordingPath).split('/'));
+}
+
+async function readExistingMetadataTimelineEvents(
+  config: BravePawsServerConfig,
+  relativeRecordingPath: string,
+): Promise<SessionTimelineEvent[]> {
+  const metadataFilePath = buildMetadataFilePath(config, relativeRecordingPath);
+
+  try {
+    const raw = await fs.readFile(metadataFilePath, 'utf8');
+    const parsed = JSON.parse(raw) as { timeline?: { events?: unknown } };
+    return normalizeTimelineEvents(parsed.timeline?.events);
+  } catch {
+    return [];
+  }
 }
 
 async function readFileSize(filePath: string): Promise<number | null> {
@@ -379,6 +456,7 @@ export function buildRecordingMetadataSidecar(options: {
       steps: (sessionSnapshot?.steps ?? []).map((step, index) => ({
         index,
         plannedDurationSeconds: step.durationSeconds,
+        actualDurationSeconds: step.actualDurationSeconds ?? null,
         status: step.status,
       })),
     },
@@ -414,7 +492,10 @@ export async function finalizeRecordingMetadata(options: {
   }
 
   const resolvedRecordingPath = path.join(options.config.recordingsDir, ...recording.relativeFilePath.split('/'));
-  const normalizedTimelineEvents = normalizeTimelineEvents(options.timelineEvents);
+  const providedTimelineEvents = normalizeTimelineEvents(options.timelineEvents);
+  const normalizedTimelineEvents = providedTimelineEvents.length > 0
+    ? providedTimelineEvents
+    : await readExistingMetadataTimelineEvents(options.config, recording.relativeFilePath);
   const measuredSizeBytes = recording.sizeBytes ?? await readFileSize(resolvedRecordingPath);
   const measuredDurationSeconds = recording.durationSeconds ?? await probeMediaDurationSeconds(resolvedRecordingPath);
   const metadataRelativePath = buildMetadataRelativePath(recording.relativeFilePath);
@@ -427,6 +508,7 @@ export async function finalizeRecordingMetadata(options: {
   };
 
   const chapters = deriveRecordingChapters({
+    sessionSnapshot: options.sessionSnapshot,
     timelineEvents: normalizedTimelineEvents,
     recordingStartedAt: nextRecording.startedAt,
     recordingStoppedAt: nextRecording.stoppedAt,

--- a/apps/brave-paws-server/src/recordingMetadata.ts
+++ b/apps/brave-paws-server/src/recordingMetadata.ts
@@ -218,6 +218,61 @@ function clampMilliseconds(value: number, minValue: number, maxValue: number): n
   return Math.min(Math.max(value, minValue), maxValue);
 }
 
+function getRecordingTimelineLengthMs(options: {
+  recordingStartedAt?: string | null;
+  recordingStoppedAt?: string | null;
+  recordingDurationSeconds?: number | null;
+}): number | null {
+  const recordingStartedAtMs = options.recordingStartedAt ? Date.parse(options.recordingStartedAt) : Number.NaN;
+  const recordingStoppedAtMs = options.recordingStoppedAt ? Date.parse(options.recordingStoppedAt) : Number.NaN;
+
+  if (Number.isFinite(recordingStartedAtMs) && Number.isFinite(recordingStoppedAtMs)) {
+    return Math.max(0, recordingStoppedAtMs - recordingStartedAtMs);
+  }
+
+  if (options.recordingDurationSeconds != null) {
+    return Math.max(0, Math.round(options.recordingDurationSeconds * 1000));
+  }
+
+  return null;
+}
+
+function resolveSafeRelativeRecordingPath(config: BravePawsServerConfig, relativeRecordingPath: string): {
+  safeRelativePath: string;
+  resolvedRecordingPath: string;
+  metadataRelativePath: string;
+  metadataFilePath: string;
+} | null {
+  const segments = relativeRecordingPath
+    .split('/')
+    .filter(Boolean);
+
+  if (!segments.length || segments.some((segment) => segment === '.' || segment === '..' || segment.includes('..') || segment.includes('\\'))) {
+    return null;
+  }
+
+  const resolvedRecordingPath = path.resolve(config.recordingsDir, ...segments);
+  const relativeResolved = path.relative(config.recordingsDir, resolvedRecordingPath);
+  if (relativeResolved.startsWith('..') || path.isAbsolute(relativeResolved)) {
+    return null;
+  }
+
+  const safeRelativePath = relativeResolved.split(path.sep).join('/');
+  const metadataRelativePath = buildMetadataRelativePath(safeRelativePath);
+  const metadataFilePath = path.resolve(config.recordingsDir, ...metadataRelativePath.split('/'));
+  const metadataRelativeResolved = path.relative(config.recordingsDir, metadataFilePath);
+  if (metadataRelativeResolved.startsWith('..') || path.isAbsolute(metadataRelativeResolved)) {
+    return null;
+  }
+
+  return {
+    safeRelativePath,
+    resolvedRecordingPath,
+    metadataRelativePath,
+    metadataFilePath,
+  };
+}
+
 export function deriveRecordingChapters(options: {
   sessionSnapshot?: Session | null;
   timelineEvents: SessionTimelineEvent[];
@@ -230,6 +285,7 @@ export function deriveRecordingChapters(options: {
 
   if (sessionSnapshot?.steps.length) {
     const snapshotChapters: RecordingMetadataChapter[] = [];
+    const recordingTimelineLengthMs = getRecordingTimelineLengthMs(options);
     let cursorMs = 0;
 
     for (let index = 0; index < sessionSnapshot.steps.length; index += 1) {
@@ -241,16 +297,26 @@ export function deriveRecordingChapters(options: {
         continue;
       }
 
+      const startTimeMs = recordingTimelineLengthMs != null
+        ? clampMilliseconds(cursorMs, 0, recordingTimelineLengthMs)
+        : cursorMs;
+      const endTimeMs = recordingTimelineLengthMs != null
+        ? clampMilliseconds(cursorMs + durationMs, startTimeMs, recordingTimelineLengthMs)
+        : cursorMs + durationMs;
+      if (endTimeMs <= startTimeMs) {
+        break;
+      }
+
       snapshotChapters.push({
         index: snapshotChapters.length + 1,
         title,
-        startTimeMs: cursorMs,
-        endTimeMs: cursorMs + durationMs,
-        startSeconds: Number((cursorMs / 1000).toFixed(3)),
-        endSeconds: Number(((cursorMs + durationMs) / 1000).toFixed(3)),
+        startTimeMs,
+        endTimeMs,
+        startSeconds: Number((startTimeMs / 1000).toFixed(3)),
+        endSeconds: Number((endTimeMs / 1000).toFixed(3)),
         sourceEventSequence: null,
       });
-      cursorMs += durationMs;
+      cursorMs = endTimeMs;
     }
 
     if (snapshotChapters.length > 0 && sessionSnapshot.steps.some((step) => step.actualDurationSeconds != null)) {
@@ -491,15 +557,18 @@ export async function finalizeRecordingMetadata(options: {
     return recording;
   }
 
-  const resolvedRecordingPath = path.join(options.config.recordingsDir, ...recording.relativeFilePath.split('/'));
+  const resolvedPaths = resolveSafeRelativeRecordingPath(options.config, recording.relativeFilePath);
+  if (!resolvedPaths) {
+    return recording;
+  }
+
+  const { resolvedRecordingPath, metadataRelativePath, metadataFilePath, safeRelativePath } = resolvedPaths;
   const providedTimelineEvents = normalizeTimelineEvents(options.timelineEvents);
   const normalizedTimelineEvents = providedTimelineEvents.length > 0
     ? providedTimelineEvents
-    : await readExistingMetadataTimelineEvents(options.config, recording.relativeFilePath);
+    : await readExistingMetadataTimelineEvents(options.config, safeRelativePath);
   const measuredSizeBytes = recording.sizeBytes ?? await readFileSize(resolvedRecordingPath);
   const measuredDurationSeconds = recording.durationSeconds ?? await probeMediaDurationSeconds(resolvedRecordingPath);
-  const metadataRelativePath = buildMetadataRelativePath(recording.relativeFilePath);
-  const metadataFilePath = buildMetadataFilePath(options.config, recording.relativeFilePath);
   const nextRecording: SessionRecording = {
     ...recording,
     sizeBytes: measuredSizeBytes,

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -38,6 +38,7 @@ const JSON_HEADERS = {
 const CORS_ALLOWED_METHODS = 'GET,POST,PUT,OPTIONS';
 const CORS_ALLOWED_HEADERS = 'content-type,x-brave-paws-token';
 const RECORDING_STOP_REQUEST_MAX_BYTES = 512 * 1024;
+const RECORDING_ARTIFACT_FINALIZE_CONCURRENCY = 2;
 
 function buildRecordingArtifactFingerprint(session: Session): string | null {
   if (session.recording?.status !== 'completed' || !session.recording.relativeFilePath) {
@@ -89,6 +90,30 @@ async function finalizeSessionRecordingArtifacts(config: BravePawsServerConfig, 
   };
 }
 
+async function mapWithConcurrencyLimit<T, R>(
+  values: T[],
+  limit: number,
+  mapper: (value: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (!values.length) {
+    return [];
+  }
+
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  const workerCount = Math.max(1, Math.min(limit, values.length));
+
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (nextIndex < values.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapper(values[currentIndex]!, currentIndex);
+    }
+  }));
+
+  return results;
+}
+
 async function finalizeSessionsRecordingArtifacts(
   config: BravePawsServerConfig,
   sessions: Session[],
@@ -96,7 +121,7 @@ async function finalizeSessionsRecordingArtifacts(
 ): Promise<Session[]> {
   const previousById = new Map(existingSessions.map((session) => [session.id, session]));
 
-  return Promise.all(sessions.map(async (session) => {
+  return mapWithConcurrencyLimit(sessions, RECORDING_ARTIFACT_FINALIZE_CONCURRENCY, async (session) => {
     const nextFingerprint = buildRecordingArtifactFingerprint(session);
     if (!nextFingerprint) {
       return session;
@@ -109,7 +134,7 @@ async function finalizeSessionsRecordingArtifacts(
       || session.recording.chapterCount == null;
 
     return needsRefresh ? finalizeSessionRecordingArtifacts(config, session) : session;
-  }));
+  });
 }
 
 class JsonBodyTooLargeError extends Error {

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -15,7 +15,7 @@ import {
   type SessionRecordingCapability,
   type SessionRecordingController,
 } from './recordingControl.js';
-import { normalizeTimelineEvents } from './recordingMetadata.js';
+import { finalizeRecordingMetadata, normalizeTimelineEvents } from './recordingMetadata.js';
 import {
   buildPairingAppUrl,
   consumePairing,
@@ -38,6 +38,79 @@ const JSON_HEADERS = {
 const CORS_ALLOWED_METHODS = 'GET,POST,PUT,OPTIONS';
 const CORS_ALLOWED_HEADERS = 'content-type,x-brave-paws-token';
 const RECORDING_STOP_REQUEST_MAX_BYTES = 512 * 1024;
+
+function buildRecordingArtifactFingerprint(session: Session): string | null {
+  if (session.recording?.status !== 'completed' || !session.recording.relativeFilePath) {
+    return null;
+  }
+
+  return JSON.stringify({
+    date: session.date,
+    status: session.status,
+    totalDurationSeconds: session.totalDurationSeconds,
+    steps: session.steps.map((step) => ({
+      durationSeconds: step.durationSeconds,
+      actualDurationSeconds: step.actualDurationSeconds ?? null,
+      status: step.status,
+    })),
+    recording: {
+      status: session.recording.status,
+      provider: session.recording.provider,
+      sessionId: session.recording.sessionId,
+      startedAt: session.recording.startedAt ?? null,
+      stoppedAt: session.recording.stoppedAt ?? null,
+      relativeFilePath: session.recording.relativeFilePath,
+      durationSeconds: session.recording.durationSeconds ?? null,
+      hasAudio: session.recording.hasAudio ?? false,
+      metadataRelativeFilePath: session.recording.metadataRelativeFilePath ?? null,
+      chapterCount: session.recording.chapterCount ?? null,
+    },
+  });
+}
+
+async function finalizeSessionRecordingArtifacts(config: BravePawsServerConfig, session: Session): Promise<Session> {
+  if (!session.recording) {
+    return session;
+  }
+
+  const finalizedRecording = await finalizeRecordingMetadata({
+    config,
+    recording: session.recording,
+    sessionSnapshot: session,
+  });
+
+  if (finalizedRecording === session.recording) {
+    return session;
+  }
+
+  return {
+    ...session,
+    recording: finalizedRecording,
+  };
+}
+
+async function finalizeSessionsRecordingArtifacts(
+  config: BravePawsServerConfig,
+  sessions: Session[],
+  existingSessions: Session[] = [],
+): Promise<Session[]> {
+  const previousById = new Map(existingSessions.map((session) => [session.id, session]));
+
+  return Promise.all(sessions.map(async (session) => {
+    const nextFingerprint = buildRecordingArtifactFingerprint(session);
+    if (!nextFingerprint) {
+      return session;
+    }
+
+    const previousSession = previousById.get(session.id);
+    const previousFingerprint = previousSession ? buildRecordingArtifactFingerprint(previousSession) : null;
+    const needsRefresh = previousFingerprint !== nextFingerprint
+      || !session.recording?.metadataRelativeFilePath
+      || session.recording.chapterCount == null;
+
+    return needsRefresh ? finalizeSessionRecordingArtifacts(config, session) : session;
+  }));
+}
 
 class JsonBodyTooLargeError extends Error {
   constructor(maxBytes: number) {
@@ -781,7 +854,8 @@ async function handleApiRequest(
       return;
     }
 
-    const store = await upsertSession(config.dataFilePath, payload);
+    const session = await finalizeSessionRecordingArtifacts(config, payload);
+    const store = await upsertSession(config.dataFilePath, session);
     sendJson(response, 201, store);
     return;
   }
@@ -800,7 +874,9 @@ async function handleApiRequest(
 
     const payload = await readJsonBody<{ sessions?: Session[] }>(request);
     const sessions = Array.isArray(payload.sessions) ? payload.sessions : [];
-    const store = await writeSessionStore(config.dataFilePath, sessions);
+    const existingStore = await readSessionStore(config.dataFilePath);
+    const finalizedSessions = await finalizeSessionsRecordingArtifacts(config, sessions, existingStore.sessions);
+    const store = await writeSessionStore(config.dataFilePath, finalizedSessions);
     sendJson(response, 200, store);
     return;
   }
@@ -920,10 +996,10 @@ async function handleApiRequest(
       }
 
       const payload = await readJsonBody<Session>(request);
-      const nextSession = {
+      const nextSession = await finalizeSessionRecordingArtifacts(config, {
         ...payload,
         id: sessionId,
-      };
+      });
       const updatedStore = await upsertSession(config.dataFilePath, nextSession);
       sendJson(response, 200, updatedStore);
       return;

--- a/apps/brave-paws-server/src/sessionIdentity.ts
+++ b/apps/brave-paws-server/src/sessionIdentity.ts
@@ -22,6 +22,7 @@ function buildSessionFingerprint(session: Omit<Session, 'id'> | Session): string
     status: session.status,
     steps: session.steps.map((step) => ({
       durationSeconds: step.durationSeconds,
+      actualDurationSeconds: step.actualDurationSeconds ?? null,
       status: step.status,
     })),
   });

--- a/apps/brave-paws-server/src/types.ts
+++ b/apps/brave-paws-server/src/types.ts
@@ -3,6 +3,7 @@ export type StepStatus = 'pending' | 'completed' | 'aborted';
 export type Step = {
   id: string;
   durationSeconds: number;
+  actualDurationSeconds?: number | null;
   status: StepStatus;
 };
 

--- a/apps/brave-paws-server/tests/recordingMetadata.test.ts
+++ b/apps/brave-paws-server/tests/recordingMetadata.test.ts
@@ -1,11 +1,16 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
   buildRecordingMetadataSidecar,
   deriveRecordingChapters,
+  finalizeRecordingMetadata,
   normalizeTimelineEvents,
 } from '../src/recordingMetadata.ts';
+import type { BravePawsServerConfig } from '../src/config.ts';
 import type { Session, SessionRecording, SessionTimelineEvent } from '../src/types.ts';
 
 test('deriveRecordingChapters uses actual runtime event timing instead of naive planned duration sums', () => {
@@ -127,6 +132,89 @@ test('deriveRecordingChapters falls back to session snapshot actual durations wh
     { title: 'Step 1 · 42s completed', startSeconds: 0, endSeconds: 42 },
     { title: 'Step 2 · 18s aborted', startSeconds: 42, endSeconds: 60 },
   ]);
+});
+
+test('deriveRecordingChapters clamps snapshot-derived chapters to the captured recording length', () => {
+  const sessionSnapshot: Session = {
+    id: 'session-clamped',
+    date: '2026-05-10T09:00:00.000Z',
+    totalDurationSeconds: 75,
+    status: 'completed',
+    steps: [
+      { id: 'step-1', durationSeconds: 30, actualDurationSeconds: 42, status: 'completed' },
+      { id: 'step-2', durationSeconds: 20, actualDurationSeconds: 18, status: 'completed' },
+    ],
+  };
+
+  const chapters = deriveRecordingChapters({
+    sessionSnapshot,
+    timelineEvents: [],
+    recordingStartedAt: '2026-05-10T09:00:00.000Z',
+    recordingStoppedAt: '2026-05-10T09:00:50.000Z',
+  });
+
+  assert.deepEqual(chapters.map((chapter) => ({ title: chapter.title, startSeconds: chapter.startSeconds, endSeconds: chapter.endSeconds })), [
+    { title: 'Step 1 · 42s completed', startSeconds: 0, endSeconds: 42 },
+    { title: 'Step 2 · 18s completed', startSeconds: 42, endSeconds: 50 },
+  ]);
+});
+
+test('finalizeRecordingMetadata ignores unsafe recording relative paths', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-recording-metadata-'));
+
+  try {
+    const config: BravePawsServerConfig = {
+      host: '127.0.0.1',
+      port: 0,
+      publicBaseUrl: null,
+      landingBasePath: '/separation/',
+      appBasePath: '/separation/app/',
+      apiBasePath: '/separation/api/',
+      cameraBasePath: '/separation/camera/',
+      healthPath: '/separation/api/health',
+      clientDiagnosticsPath: '/separation/api/client-diagnostics',
+      landingDistDir: path.join(tempDir, 'landing'),
+      appDistDir: path.join(tempDir, 'app'),
+      dataDir: tempDir,
+      dataFilePath: path.join(tempDir, 'sessions.json'),
+      pairingStoreFilePath: path.join(tempDir, 'pairings.json'),
+      pairingEnabled: false,
+      cameraUpstreamBaseUrl: 'http://127.0.0.1:9999/',
+      cameraControlProvider: 'none',
+      cameraControlLabel: 'Camera streaming',
+      cameraControlStatusCommand: null,
+      cameraControlEnableCommand: null,
+      cameraControlDisableCommand: null,
+      recordingProvider: 'none',
+      recordingLabel: 'Session recording',
+      recordingStatusCommand: null,
+      recordingStartCommand: null,
+      recordingStopCommand: null,
+      authToken: null,
+      corsAllowedOrigins: [],
+      recordingsDir: path.join(tempDir, 'recordings'),
+    };
+
+    const recording: SessionRecording = {
+      status: 'completed',
+      sessionId: 'session-unsafe',
+      provider: 'command',
+      startedAt: '2026-05-10T09:00:00.000Z',
+      stoppedAt: '2026-05-10T09:00:05.000Z',
+      relativeFilePath: '../escape.mp4',
+      durationSeconds: 5,
+      hasAudio: false,
+    };
+
+    const finalized = await finalizeRecordingMetadata({
+      config,
+      recording,
+    });
+
+    assert.deepEqual(finalized, recording);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test('buildRecordingMetadataSidecar emits the canonical v1 sidecar structure', () => {

--- a/apps/brave-paws-server/tests/recordingMetadata.test.ts
+++ b/apps/brave-paws-server/tests/recordingMetadata.test.ts
@@ -90,6 +90,45 @@ test('deriveRecordingChapters uses actual runtime event timing instead of naive 
   ]);
 });
 
+test('deriveRecordingChapters falls back to session snapshot actual durations when they are available', () => {
+  const sessionSnapshot: Session = {
+    id: 'session-actuals',
+    date: '2026-05-10T09:00:00.000Z',
+    totalDurationSeconds: 75,
+    status: 'completed',
+    steps: [
+      { id: 'step-1', durationSeconds: 30, actualDurationSeconds: 42, status: 'completed' },
+      { id: 'step-2', durationSeconds: 20, actualDurationSeconds: 18, status: 'aborted' },
+    ],
+  };
+
+  const chapters = deriveRecordingChapters({
+    sessionSnapshot,
+    timelineEvents: normalizeTimelineEvents([
+      {
+        sequence: 0,
+        type: 'step_started',
+        occurredAt: '2026-05-10T09:00:00.000Z',
+        sessionElapsedSeconds: 0,
+        sessionRunning: true,
+        currentStepIndex: 0,
+        stepId: 'step-1',
+        stepStatus: 'pending',
+        stepRunning: true,
+        stepElapsedSeconds: 0,
+        stepDurationSeconds: 30,
+      },
+    ]),
+    recordingStartedAt: '2026-05-10T09:00:00.000Z',
+    recordingStoppedAt: '2026-05-10T09:01:15.000Z',
+  });
+
+  assert.deepEqual(chapters.map((chapter) => ({ title: chapter.title, startSeconds: chapter.startSeconds, endSeconds: chapter.endSeconds })), [
+    { title: 'Step 1 · 42s completed', startSeconds: 0, endSeconds: 42 },
+    { title: 'Step 2 · 18s aborted', startSeconds: 42, endSeconds: 60 },
+  ]);
+});
+
 test('buildRecordingMetadataSidecar emits the canonical v1 sidecar structure', () => {
   const sessionSnapshot: Session = {
     id: 'session-123',
@@ -97,8 +136,8 @@ test('buildRecordingMetadataSidecar emits the canonical v1 sidecar structure', (
     totalDurationSeconds: 60,
     status: 'completed',
     steps: [
-      { id: 'step-1', durationSeconds: 30, status: 'completed' },
-      { id: 'step-2', durationSeconds: 20, status: 'completed' },
+      { id: 'step-1', durationSeconds: 30, actualDurationSeconds: 32, status: 'completed' },
+      { id: 'step-2', durationSeconds: 20, actualDurationSeconds: 18, status: 'completed' },
     ],
   };
   const recording: SessionRecording = {
@@ -150,6 +189,7 @@ test('buildRecordingMetadataSidecar emits the canonical v1 sidecar structure', (
   assert.equal(sidecar.recordingFile.relativePath, '2026/05/10/session-123.mp4');
   assert.equal(sidecar.recordingFile.metadataRelativePath, '2026/05/10/session-123.brave-paws.json');
   assert.equal(sidecar.session.stepCount, 2);
+  assert.equal(sidecar.session.steps[0]?.actualDurationSeconds, 32);
   assert.equal(sidecar.recording.chapterCount, chapters.length);
   assert.equal(sidecar.recording.chaptersEmbedded, true);
   assert.equal(sidecar.timeline.eventCount, 1);


### PR DESCRIPTION
## Summary
- switch live session timing to a stopwatch-first UX while keeping goal durations visible as guidance
- persist actual per-step durations across app/server/session edit flows and prefer them in history, graphs, exports, and identity logic
- regenerate recording metadata and MP4 chapters from canonical actual session timing when saved sessions are edited

## Testing
- npm run app:lint
- npm run app:test
- npm run server:lint
- npm run server:test
- npm run build
- npx playwright test e2e/session-flow.spec.ts