### PR TITLE
Add Brave Paws settings page and longest-step auto-increment

### DIFF
--- a/apps/brave-paws-app/e2e/settings.spec.ts
+++ b/apps/brave-paws-app/e2e/settings.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Settings', () => {
+  test('navigates to the settings page from the dashboard and back', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'Settings' }).click();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByText('Longest departure auto-increment')).toBeVisible();
+    await expect(page.getByLabel('Backend server URL')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Back to dashboard' }).click();
+    await expect(page.getByRole('heading', { name: 'Brave Paws' })).toBeVisible();
+  });
+
+  test('uses saved settings to auto-increment the longest planned step from the previous session', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('csa_tracker_sessions', JSON.stringify([
+        {
+          id: 'session-1',
+          date: '2026-05-15T10:00:00.000Z',
+          steps: [
+            { id: 'step-1', durationSeconds: 30, status: 'completed' },
+            { id: 'step-2', durationSeconds: 480, status: 'completed' },
+            { id: 'step-3', durationSeconds: 45, status: 'completed' },
+          ],
+          totalDurationSeconds: 555,
+          status: 'completed',
+        },
+      ]));
+      localStorage.setItem('brave_paws_settings', JSON.stringify({
+        longestDepartureIncrement: {
+          mode: 'percentage',
+          value: 10,
+        },
+      }));
+    });
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Start Training' }).click();
+
+    await expect(page.getByRole('heading', { name: "Plan Today's Training" })).toBeVisible();
+    await expect(page.locator('span').filter({ hasText: '8m 50s' }).first()).toBeVisible();
+    await expect(page.locator('span').filter({ hasText: '30s' }).first()).toBeVisible();
+    await expect(page.locator('span').filter({ hasText: '45s' }).first()).toBeVisible();
+  });
+});

--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -11,12 +11,13 @@ import { SessionView } from './components/SessionView';
 import { InfoView } from './components/InfoView';
 import { CameraStreamingControl } from './components/CameraStreamingControl';
 import { StorageSync } from './components/StorageSync';
-import { BackendConnectionSettings } from './components/BackendConnectionSettings';
+import { SettingsView } from './components/SettingsView';
 import { useCameraStreamingControl } from './hooks/useCameraStreamingControl';
 import { useStorageSync } from './hooks/useStorageSync';
 import { exportToCSV, parseCSV } from './utils/export';
 import { CAMERA_URL_STORAGE_KEY, getCameraUrlFromSearch } from './utils/cameraUrl';
 import { loadStoredBackendRootUrl } from './config';
+import { buildNewSessionSteps, loadAppSettings, saveAppSettings } from './settings';
 import { PAIRING_TOKEN_QUERY_PARAM, resolveCameraUrlFromPairingToken } from './utils/pairingToken';
 import { installGlobalClientDiagnostics } from './utils/clientDiagnostics';
 import {
@@ -28,7 +29,7 @@ import {
 } from './utils/activeSessionStorage';
 import { ArrowLeft } from 'lucide-react';
 
-type View = 'dashboard' | 'config' | 'active' | 'complete' | 'graph' | 'history' | 'session-view' | 'info';
+type View = 'dashboard' | 'config' | 'active' | 'complete' | 'graph' | 'history' | 'session-view' | 'info' | 'settings';
 
 const DEFAULT_STEPS: Step[] = [
   { id: crypto.randomUUID(), durationSeconds: 30, status: 'pending' },
@@ -48,6 +49,7 @@ export default function App() {
   const [activeSessionState, setActiveSessionState] = useState<ActiveSessionState | null>(restoredActiveSessionState);
   const [cameraUrl, setCameraUrl] = useState(() => getCameraUrlFromSearch(window.location.search) || localStorage.getItem(CAMERA_URL_STORAGE_KEY) || '');
   const [backendRootUrl, setBackendRootUrl] = useState<string | null>(() => loadStoredBackendRootUrl());
+  const [appSettings, setAppSettings] = useState(() => loadAppSettings());
   const cameraStreamingControl = useCameraStreamingControl();
   const wasTrainingActiveRef = useRef(false);
   const pendingSessionCameraStateRef = useRef<boolean | null>(restoredActiveSessionState ? true : null);
@@ -102,6 +104,10 @@ export default function App() {
     clearActiveSessionState();
   }, [activeSessionState]);
 
+  useEffect(() => {
+    saveAppSettings(appSettings);
+  }, [appSettings]);
+
   const handleImportSessions = useCallback((imported: Session[]) => {
     replaceSessions(imported);
   }, [replaceSessions]);
@@ -144,12 +150,7 @@ export default function App() {
     if (sessions.length > 0) {
       const sorted = [...sessions].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
       const lastSession = sorted[0];
-      initialSteps = lastSession.steps.map((step) => ({
-        ...step,
-        id: crypto.randomUUID(),
-        actualDurationSeconds: null,
-        status: 'pending',
-      }));
+      initialSteps = buildNewSessionSteps(lastSession.steps, appSettings);
     }
 
     const newSession: Session = {
@@ -199,6 +200,7 @@ export default function App() {
           onViewGraph={() => setCurrentView('graph')}
           onViewHistory={() => setCurrentView('history')}
           onViewInfo={() => setCurrentView('info')}
+          onViewSettings={() => setCurrentView('settings')}
           onViewSession={(session) => {
             setActiveSession(session);
             setPreviousView('dashboard');
@@ -208,13 +210,6 @@ export default function App() {
           storageSync={
             <StorageSync
               provider={storageSync.provider}
-              backendConnection={
-                <BackendConnectionSettings
-                  currentBackendRootUrl={backendRootUrl}
-                  isBackendAvailable={storageSync.provider.isAvailable}
-                  onBackendRootUrlChange={setBackendRootUrl}
-                />
-              }
             />
           }
           isBackendUnavailable={!storageSync.provider.isAvailable}
@@ -311,6 +306,17 @@ export default function App() {
 
       {currentView === 'info' && (
         <InfoView onBack={() => setCurrentView('dashboard')} />
+      )}
+
+      {currentView === 'settings' && (
+        <SettingsView
+          settings={appSettings}
+          currentBackendRootUrl={backendRootUrl}
+          isBackendAvailable={storageSync.provider.isAvailable}
+          onBack={() => setCurrentView('dashboard')}
+          onBackendRootUrlChange={setBackendRootUrl}
+          onSettingsChange={setAppSettings}
+        />
       )}
     </div>
   );

--- a/apps/brave-paws-app/src/components/Dashboard.tsx
+++ b/apps/brave-paws-app/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { Session } from '../types';
 import { formatDuration } from '../utils/format';
-import { Play, BarChart2, History, Heart, Info, Server } from 'lucide-react';
+import { Play, BarChart2, History, Heart, Info, Server, Settings } from 'lucide-react';
 import { format } from 'date-fns';
 import { ReactNode } from 'react';
 import { getAbortedStepCount, getCompletedStepCount, getRecordedStepDurationSeconds } from '../utils/sessionStatus';
@@ -11,6 +11,7 @@ type Props = {
   onViewGraph: () => void;
   onViewHistory: () => void;
   onViewInfo: () => void;
+  onViewSettings: () => void;
   onViewSession: (session: Session) => void;
   cameraStreamingControl?: ReactNode;
   storageSync?: ReactNode;
@@ -29,6 +30,7 @@ export function Dashboard({
   onViewGraph,
   onViewHistory,
   onViewInfo,
+  onViewSettings,
   onViewSession,
   cameraStreamingControl,
   storageSync,
@@ -39,7 +41,14 @@ export function Dashboard({
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-8">
-      <header className="text-center py-10">
+      <header className="relative text-center py-10">
+        <button
+          onClick={onViewSettings}
+          aria-label="Settings"
+          className="absolute right-0 top-6 inline-flex items-center justify-center rounded-full border border-slate-200 bg-white p-3 text-slate-500 shadow-sm transition-colors hover:border-rose-200 hover:bg-rose-50 hover:text-rose-500"
+        >
+          <Settings size={20} />
+        </button>
         <div className="inline-flex items-center justify-center p-3 bg-rose-100 text-rose-500 rounded-full mb-4">
           <Heart size={32} fill="currentColor" />
         </div>

--- a/apps/brave-paws-app/src/components/SettingsView.tsx
+++ b/apps/brave-paws-app/src/components/SettingsView.tsx
@@ -93,7 +93,7 @@ export function SettingsView({
                 id="longest-departure-value"
                 type="number"
                 min="0"
-                step={incrementMode === 'percentage' ? '1' : '1'}
+                step="1"
                 value={Number.isFinite(incrementValue) ? String(incrementValue) : '0'}
                 onChange={(event) => handleValueChange(event.target.value)}
                 className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-rose-300 focus:bg-white focus:ring-2 focus:ring-rose-100"

--- a/apps/brave-paws-app/src/components/SettingsView.tsx
+++ b/apps/brave-paws-app/src/components/SettingsView.tsx
@@ -1,0 +1,136 @@
+import { ArrowLeft, Cog, Wifi } from 'lucide-react';
+
+import type { AppSettings, LongestStepAutoIncrementMode } from '../settings';
+import { BackendConnectionSettings } from './BackendConnectionSettings';
+
+type Props = {
+  settings: AppSettings;
+  currentBackendRootUrl: string | null;
+  isBackendAvailable: boolean;
+  onBack: () => void;
+  onBackendRootUrlChange: (backendRootUrl: string | null) => void;
+  onSettingsChange: (settings: AppSettings) => void;
+};
+
+export function SettingsView({
+  settings,
+  currentBackendRootUrl,
+  isBackendAvailable,
+  onBack,
+  onBackendRootUrlChange,
+  onSettingsChange,
+}: Props) {
+  const incrementMode = settings.longestDepartureIncrement.mode;
+  const incrementValue = settings.longestDepartureIncrement.value;
+
+  const handleModeChange = (mode: LongestStepAutoIncrementMode) => {
+    onSettingsChange({
+      ...settings,
+      longestDepartureIncrement: {
+        ...settings.longestDepartureIncrement,
+        mode,
+      },
+    });
+  };
+
+  const handleValueChange = (rawValue: string) => {
+    const parsed = Number.parseFloat(rawValue);
+    onSettingsChange({
+      ...settings,
+      longestDepartureIncrement: {
+        ...settings.longestDepartureIncrement,
+        value: Number.isFinite(parsed) ? Math.max(0, parsed) : 0,
+      },
+    });
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-6">
+      <header className="flex items-center justify-between py-6">
+        <button
+          onClick={onBack}
+          className="p-3 text-slate-400 hover:text-rose-500 hover:bg-rose-50 rounded-full transition-colors"
+          aria-label="Back to dashboard"
+        >
+          <ArrowLeft size={24} />
+        </button>
+        <div className="text-center">
+          <h1 className="text-2xl font-serif font-bold text-slate-800">Settings</h1>
+          <p className="text-sm text-slate-500 mt-1 italic">Tweak how Brave Paws behaves on this device.</p>
+        </div>
+        <div className="w-12" />
+      </header>
+
+      <section className="bg-white rounded-3xl shadow-sm border border-slate-100 p-6 sm:p-8 space-y-5">
+        <div className="flex items-start gap-3">
+          <div className="rounded-2xl bg-rose-100 p-2.5 text-rose-500">
+            <Cog size={18} />
+          </div>
+          <div>
+            <h2 className="text-lg font-bold text-slate-800">Training defaults</h2>
+            <p className="mt-1 text-sm text-slate-500">
+              When you start a new session from your latest history, Brave Paws can gently extend the longest planned departure automatically.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <label className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400" htmlFor="longest-departure-mode">
+            Longest departure auto-increment
+          </label>
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,12rem)_minmax(0,1fr)]">
+            <select
+              id="longest-departure-mode"
+              value={incrementMode}
+              onChange={(event) => handleModeChange(event.target.value as LongestStepAutoIncrementMode)}
+              className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-rose-300 focus:bg-white focus:ring-2 focus:ring-rose-100"
+            >
+              <option value="minutes">Minutes</option>
+              <option value="percentage">Percentage</option>
+            </select>
+            <div className="space-y-2">
+              <input
+                id="longest-departure-value"
+                type="number"
+                min="0"
+                step={incrementMode === 'percentage' ? '1' : '1'}
+                value={Number.isFinite(incrementValue) ? String(incrementValue) : '0'}
+                onChange={(event) => handleValueChange(event.target.value)}
+                className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-rose-300 focus:bg-white focus:ring-2 focus:ring-rose-100"
+                aria-describedby="longest-departure-help"
+              />
+              <p id="longest-departure-help" className="text-xs text-slate-500">
+                {incrementMode === 'percentage'
+                  ? 'Adds this percentage to the longest planned step from your last session, then rounds the new duration to the nearest 5 seconds.'
+                  : 'Adds this many minutes to the longest planned step from your last session when you start a new one.'}
+              </p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            Saved automatically on this device.
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white rounded-3xl shadow-sm border border-slate-100 p-6 sm:p-8 space-y-5">
+        <div className="flex items-start gap-3">
+          <div className="rounded-2xl bg-sky-100 p-2.5 text-sky-600">
+            <Wifi size={18} />
+          </div>
+          <div>
+            <h2 className="text-lg font-bold text-slate-800">Backend connection</h2>
+            <p className="mt-1 text-sm text-slate-500">
+              Point this browser at the Brave Paws backend you want to use for sync, live camera controls, and recordings.
+            </p>
+          </div>
+        </div>
+
+        <BackendConnectionSettings
+          currentBackendRootUrl={currentBackendRootUrl}
+          isBackendAvailable={isBackendAvailable}
+          onBackendRootUrlChange={onBackendRootUrlChange}
+        />
+      </section>
+    </div>
+  );
+}

--- a/apps/brave-paws-app/src/components/StorageSync.tsx
+++ b/apps/brave-paws-app/src/components/StorageSync.tsx
@@ -1,14 +1,12 @@
-import { type ReactNode } from 'react';
 import { AlertCircle, Check, Loader2, RefreshCw, Server } from 'lucide-react';
 
 import type { StorageProviderState } from '../hooks/useStorageSync';
 
 type Props = {
   provider: StorageProviderState;
-  backendConnection?: ReactNode;
 };
 
-export function StorageSync({ provider, backendConnection }: Props) {
+export function StorageSync({ provider }: Props) {
   return (
     <section className="bg-white rounded-3xl shadow-sm border border-slate-100 p-6 space-y-5">
       <div className="flex items-start justify-between gap-4">
@@ -64,8 +62,6 @@ export function StorageSync({ provider, backendConnection }: Props) {
           <div className="rounded-2xl border border-slate-200 bg-white px-3 py-2">Syncs on reconnect</div>
           <div className="rounded-2xl border border-slate-200 bg-white px-3 py-2">Refreshes after saves and imports</div>
         </div>
-
-        {backendConnection}
 
         {provider.onSyncNow && provider.isAvailable ? (
           <div className="flex flex-wrap gap-2">

--- a/apps/brave-paws-app/src/settings.ts
+++ b/apps/brave-paws-app/src/settings.ts
@@ -20,6 +20,15 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   },
 };
 
+function createDefaultAppSettings(): AppSettings {
+  return {
+    longestDepartureIncrement: {
+      mode: DEFAULT_APP_SETTINGS.longestDepartureIncrement.mode,
+      value: DEFAULT_APP_SETTINGS.longestDepartureIncrement.value,
+    },
+  };
+}
+
 function getStorage(): StorageLike | null {
   if (typeof localStorage === 'undefined') {
     return null;
@@ -66,7 +75,7 @@ function normalizeValue(value: unknown): number {
 
 export function normalizeAppSettings(value: unknown): AppSettings {
   if (!value || typeof value !== 'object') {
-    return DEFAULT_APP_SETTINGS;
+    return createDefaultAppSettings();
   }
 
   const candidate = value as {
@@ -87,13 +96,13 @@ export function normalizeAppSettings(value: unknown): AppSettings {
 export function loadAppSettings(storage: StorageLike | null = getStorage()): AppSettings {
   const stored = safeStorageGet(storage, APP_SETTINGS_STORAGE_KEY);
   if (!stored) {
-    return DEFAULT_APP_SETTINGS;
+    return createDefaultAppSettings();
   }
 
   try {
     return normalizeAppSettings(JSON.parse(stored));
   } catch {
-    return DEFAULT_APP_SETTINGS;
+    return createDefaultAppSettings();
   }
 }
 

--- a/apps/brave-paws-app/src/settings.ts
+++ b/apps/brave-paws-app/src/settings.ts
@@ -1,0 +1,143 @@
+import type { Step } from './types';
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export type LongestStepAutoIncrementMode = 'minutes' | 'percentage';
+
+export type AppSettings = {
+  longestDepartureIncrement: {
+    mode: LongestStepAutoIncrementMode;
+    value: number;
+  };
+};
+
+export const APP_SETTINGS_STORAGE_KEY = 'brave_paws_settings';
+
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  longestDepartureIncrement: {
+    mode: 'minutes',
+    value: 0,
+  },
+};
+
+function getStorage(): StorageLike | null {
+  if (typeof localStorage === 'undefined') {
+    return null;
+  }
+
+  return localStorage;
+}
+
+function safeStorageGet(storage: StorageLike | null, key: string): string | null {
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeStorageSet(storage: StorageLike | null, key: string, value: string): void {
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(key, value);
+  } catch {
+    // Ignore blocked storage writes.
+  }
+}
+
+function normalizeMode(value: unknown): LongestStepAutoIncrementMode {
+  return value === 'percentage' ? 'percentage' : 'minutes';
+}
+
+function normalizeValue(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, value);
+}
+
+export function normalizeAppSettings(value: unknown): AppSettings {
+  if (!value || typeof value !== 'object') {
+    return DEFAULT_APP_SETTINGS;
+  }
+
+  const candidate = value as {
+    longestDepartureIncrement?: {
+      mode?: unknown;
+      value?: unknown;
+    };
+  };
+
+  return {
+    longestDepartureIncrement: {
+      mode: normalizeMode(candidate.longestDepartureIncrement?.mode),
+      value: normalizeValue(candidate.longestDepartureIncrement?.value),
+    },
+  };
+}
+
+export function loadAppSettings(storage: StorageLike | null = getStorage()): AppSettings {
+  const stored = safeStorageGet(storage, APP_SETTINGS_STORAGE_KEY);
+  if (!stored) {
+    return DEFAULT_APP_SETTINGS;
+  }
+
+  try {
+    return normalizeAppSettings(JSON.parse(stored));
+  } catch {
+    return DEFAULT_APP_SETTINGS;
+  }
+}
+
+export function saveAppSettings(settings: AppSettings, storage: StorageLike | null = getStorage()): AppSettings {
+  const normalized = normalizeAppSettings(settings);
+  safeStorageSet(storage, APP_SETTINGS_STORAGE_KEY, JSON.stringify(normalized));
+  return normalized;
+}
+
+function roundToNearestFiveSeconds(seconds: number): number {
+  return Math.max(0, Math.round(seconds / 5) * 5);
+}
+
+function getIncrementedLongestStepDurationSeconds(durationSeconds: number, settings: AppSettings): number {
+  const { mode, value } = settings.longestDepartureIncrement;
+  if (value <= 0) {
+    return durationSeconds;
+  }
+
+  if (mode === 'percentage') {
+    return roundToNearestFiveSeconds(durationSeconds * (1 + value / 100));
+  }
+
+  return durationSeconds + Math.round(value * 60);
+}
+
+export function buildNewSessionSteps(previousSteps: Step[], settings: AppSettings): Step[] {
+  if (previousSteps.length === 0) {
+    return [];
+  }
+
+  let longestStepIndex = 0;
+  for (let index = 1; index < previousSteps.length; index += 1) {
+    if (previousSteps[index]!.durationSeconds > previousSteps[longestStepIndex]!.durationSeconds) {
+      longestStepIndex = index;
+    }
+  }
+
+  return previousSteps.map((step, index) => ({
+    id: crypto.randomUUID(),
+    durationSeconds: index === longestStepIndex
+      ? getIncrementedLongestStepDurationSeconds(step.durationSeconds, settings)
+      : step.durationSeconds,
+    actualDurationSeconds: null,
+    status: 'pending',
+  }));
+}

--- a/apps/brave-paws-app/tests/backend-connection-ui.test.js
+++ b/apps/brave-paws-app/tests/backend-connection-ui.test.js
@@ -3,11 +3,24 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-test('dashboard storage sync includes backend connection settings with test, save, and reset affordances', () => {
+test('settings view hosts the backend connection controls instead of the dashboard storage card', () => {
+  const app = readFileSync(resolve(process.cwd(), 'src/App.tsx'), 'utf8');
+  const settingsView = readFileSync(resolve(process.cwd(), 'src/components/SettingsView.tsx'), 'utf8');
   const storageSync = readFileSync(resolve(process.cwd(), 'src/components/StorageSync.tsx'), 'utf8');
+
+  assert.match(app, /currentView === 'settings'/);
+  assert.match(settingsView, /<BackendConnectionSettings/);
+  assert.doesNotMatch(storageSync, /backendConnection/);
+});
+
+test('settings view exposes backend connection and longest departure auto-increment controls', () => {
+  const settingsView = readFileSync(resolve(process.cwd(), 'src/components/SettingsView.tsx'), 'utf8');
   const backendConnection = readFileSync(resolve(process.cwd(), 'src/components/BackendConnectionSettings.tsx'), 'utf8');
 
-  assert.match(storageSync, /backendConnection/);
+  assert.match(settingsView, /Longest departure auto-increment/);
+  assert.match(settingsView, /Minutes/);
+  assert.match(settingsView, /Percentage/);
+  assert.match(settingsView, /Saved automatically on this device/);
   assert.match(backendConnection, /Backend connection/);
   assert.match(backendConnection, /Backend server URL/);
   assert.match(backendConnection, /Test &amp; Save/);

--- a/apps/brave-paws-app/tests/settings.test.ts
+++ b/apps/brave-paws-app/tests/settings.test.ts
@@ -57,15 +57,21 @@ test('normalizeAppSettings falls back to defaults for malformed values', () => {
   });
 });
 
-test('loadAppSettings returns defaults when storage is empty', () => {
+test('loadAppSettings returns fresh default objects when storage is empty', () => {
   const storage = createStorage();
 
-  assert.deepEqual(loadAppSettings(storage), {
+  const first = loadAppSettings(storage);
+  const second = loadAppSettings(storage);
+
+  assert.deepEqual(first, {
     longestDepartureIncrement: {
       mode: 'minutes',
       value: 0,
     },
   });
+  assert.deepEqual(second, first);
+  assert.notStrictEqual(first, second);
+  assert.notStrictEqual(first.longestDepartureIncrement, second.longestDepartureIncrement);
 });
 
 test('saveAppSettings persists normalized settings', () => {

--- a/apps/brave-paws-app/tests/settings.test.ts
+++ b/apps/brave-paws-app/tests/settings.test.ts
@@ -1,0 +1,125 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  APP_SETTINGS_STORAGE_KEY,
+  buildNewSessionSteps,
+  loadAppSettings,
+  normalizeAppSettings,
+  saveAppSettings,
+} from '../src/settings.ts';
+import type { Step } from '../src/types.ts';
+
+type StorageLike = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+};
+
+function createStorage(initialEntries: Record<string, string> = {}): StorageLike {
+  const store = new Map(Object.entries(initialEntries));
+
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+}
+
+const PREVIOUS_STEPS: Step[] = [
+  { id: 'step-1', durationSeconds: 30, status: 'completed' },
+  { id: 'step-2', durationSeconds: 480, status: 'completed' },
+  { id: 'step-3', durationSeconds: 45, status: 'completed' },
+];
+
+test('normalizeAppSettings falls back to defaults for malformed values', () => {
+  assert.deepEqual(normalizeAppSettings(null), {
+    longestDepartureIncrement: {
+      mode: 'minutes',
+      value: 0,
+    },
+  });
+
+  assert.deepEqual(normalizeAppSettings({
+    longestDepartureIncrement: {
+      mode: 'nonsense',
+      value: -4,
+    },
+  }), {
+    longestDepartureIncrement: {
+      mode: 'minutes',
+      value: 0,
+    },
+  });
+});
+
+test('loadAppSettings returns defaults when storage is empty', () => {
+  const storage = createStorage();
+
+  assert.deepEqual(loadAppSettings(storage), {
+    longestDepartureIncrement: {
+      mode: 'minutes',
+      value: 0,
+    },
+  });
+});
+
+test('saveAppSettings persists normalized settings', () => {
+  const storage = createStorage();
+
+  const saved = saveAppSettings({
+    longestDepartureIncrement: {
+      mode: 'percentage',
+      value: 12,
+    },
+  }, storage);
+
+  assert.deepEqual(saved, {
+    longestDepartureIncrement: {
+      mode: 'percentage',
+      value: 12,
+    },
+  });
+  assert.equal(storage.getItem(APP_SETTINGS_STORAGE_KEY), JSON.stringify(saved));
+});
+
+test('buildNewSessionSteps adds the configured minutes to the first longest prior step', () => {
+  const steps = buildNewSessionSteps(PREVIOUS_STEPS, {
+    longestDepartureIncrement: {
+      mode: 'minutes',
+      value: 2,
+    },
+  });
+
+  assert.deepEqual(steps.map((step) => step.durationSeconds), [30, 600, 45]);
+  assert.deepEqual(steps.map((step) => step.status), ['pending', 'pending', 'pending']);
+  assert.deepEqual(steps.map((step) => step.actualDurationSeconds ?? null), [null, null, null]);
+  assert.notEqual(steps[0]?.id, PREVIOUS_STEPS[0]?.id);
+  assert.notEqual(steps[1]?.id, PREVIOUS_STEPS[1]?.id);
+});
+
+test('buildNewSessionSteps applies percentage increments and rounds to the nearest five seconds', () => {
+  const steps = buildNewSessionSteps(PREVIOUS_STEPS, {
+    longestDepartureIncrement: {
+      mode: 'percentage',
+      value: 10,
+    },
+  });
+
+  assert.deepEqual(steps.map((step) => step.durationSeconds), [30, 530, 45]);
+});
+
+test('buildNewSessionSteps leaves durations unchanged when auto-increment is disabled', () => {
+  const steps = buildNewSessionSteps(PREVIOUS_STEPS, {
+    longestDepartureIncrement: {
+      mode: 'minutes',
+      value: 0,
+    },
+  });
+
+  assert.deepEqual(steps.map((step) => step.durationSeconds), [30, 480, 45]);
+});


### PR DESCRIPTION
## Summary
- add a dedicated Settings page from the dashboard and move backend connection controls there
- persist a longest-departure auto-increment preference with minutes and percentage modes
- seed new sessions from the previous session with the configured increment applied to the longest planned step, plus unit and e2e coverage

## Testing
- npm run lint
- npm run test
- npm run build
- npm run test:e2e

## Notes
- percentage mode rounds the new longest step duration to the nearest 5 seconds
- when multiple prior steps tie for longest, this increments the first longest step deterministically