### PR TITLE
Store Brave Paws recordings on S: and disable picam on session end

### DIFF
--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -130,18 +130,40 @@ export default function App() {
 
   useEffect(() => {
     const pendingState = pendingSessionCameraStateRef.current;
-    if (pendingState == null || !cameraStreamingControl.capability.canSetEnabled) {
+    if (pendingState == null || cameraStreamingControl.isLoading || !cameraStreamingControl.capability.canSetEnabled) {
       return;
     }
 
-    void cameraStreamingControl.setEnabled(pendingState, { silent: true }).then(() => {
-      if (pendingSessionCameraStateRef.current === pendingState) {
+    if (cameraStreamingControl.capability.enabled === pendingState) {
+      pendingSessionCameraStateRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+
+    void cameraStreamingControl.setEnabled(pendingState, { silent: true }).then((nextCapability) => {
+      if (cancelled) {
+        return;
+      }
+
+      if (pendingSessionCameraStateRef.current === pendingState && nextCapability.enabled === pendingState) {
         pendingSessionCameraStateRef.current = null;
       }
     }).catch(() => {
       // Camera control is best-effort; leave the pending state so a later refresh can retry.
     });
-  }, [activeSession, currentView, cameraStreamingControl.capability.canSetEnabled, cameraStreamingControl.setEnabled]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeSession,
+    currentView,
+    cameraStreamingControl.capability.canSetEnabled,
+    cameraStreamingControl.capability.enabled,
+    cameraStreamingControl.isLoading,
+    cameraStreamingControl.setEnabled,
+  ]);
 
   const handleStartNew = () => {
     let initialSteps = DEFAULT_STEPS;
@@ -231,6 +253,7 @@ export default function App() {
           session={activeSession}
           initialState={activeSessionState ?? undefined}
           cameraUrl={cameraUrl}
+          cameraStreamingControl={cameraStreamingControl}
           onCameraUrlChange={setCameraUrl}
           onStateChange={setActiveSessionState}
           onCompleteSession={handleCompleteSession}

--- a/apps/brave-paws-app/src/components/ActiveSession.tsx
+++ b/apps/brave-paws-app/src/components/ActiveSession.tsx
@@ -262,14 +262,12 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     detail,
   }), [recordingCapability.provider]);
 
-  const disableCameraStreamingAtSessionEnd = useCallback(async () => {
-    if (!cameraStreamingControl?.capability.canSetEnabled) {
+  const disableCameraStreamingAtSessionEnd = useCallback(() => {
+    if (!cameraStreamingControl?.capability.canSetEnabled || cameraStreamingControl.capability.enabled !== true) {
       return;
     }
 
-    try {
-      await cameraStreamingControl.setEnabled(false, { silent: true });
-    } catch (cameraDisableError) {
+    void cameraStreamingControl.setEnabled(false, { silent: true }).catch((cameraDisableError) => {
       reportClientDiagnostic({
         category: 'camera_preview_issue',
         severity: 'warn',
@@ -280,7 +278,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
           sessionId: sessionRef.current.id,
         },
       });
-    }
+    });
   }, [cameraStreamingControl]);
 
   // Background Stopwatch
@@ -511,7 +509,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       }
     }
 
-    await disableCameraStreamingAtSessionEnd();
+    disableCameraStreamingAtSessionEnd();
 
     onCompleteSession({
       ...recordingSessionSnapshot,
@@ -561,7 +559,7 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       }
     }
 
-    await disableCameraStreamingAtSessionEnd();
+    disableCameraStreamingAtSessionEnd();
 
     onCancel();
   };

--- a/apps/brave-paws-app/src/components/ActiveSession.tsx
+++ b/apps/brave-paws-app/src/components/ActiveSession.tsx
@@ -7,6 +7,7 @@ import { CameraLinkInput } from './CameraLinkInput';
 import { TimerClock, getElapsedSeconds, pauseTimer, startTimer } from '../utils/timer';
 import { ActiveSessionState } from '../utils/activeSessionStorage';
 import { reportClientDiagnostic } from '../utils/clientDiagnostics';
+import type { CameraStreamingControlState } from '../hooks/useCameraStreamingControl';
 import {
   fetchSessionRecordingCapability,
   startSessionRecording,
@@ -21,6 +22,7 @@ type Props = {
   session: Session;
   initialState?: ActiveSessionState;
   cameraUrl?: string;
+  cameraStreamingControl?: Pick<CameraStreamingControlState, 'capability' | 'setEnabled'>;
   onCameraUrlChange?: (url: string) => void;
   onStateChange?: (state: ActiveSessionState) => void;
   onCompleteSession: (session: Session) => void;
@@ -39,7 +41,7 @@ export function shouldAppendInitialTimelineEvent(
   return lastTimelineEvent?.type !== 'session_resumed';
 }
 
-export function ActiveSession({ session: initialSession, initialState, cameraUrl = '', onCameraUrlChange, onStateChange, onCompleteSession, onCancel }: Props) {
+export function ActiveSession({ session: initialSession, initialState, cameraUrl = '', cameraStreamingControl, onCameraUrlChange, onStateChange, onCompleteSession, onCancel }: Props) {
   const restoredState = initialState?.session.id === initialSession.id ? initialState : undefined;
   const initialSessionClock = restoredState?.sessionClock ?? {
     startedAt: Date.now(),
@@ -259,6 +261,27 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
     chaptersEmbedded: sessionRef.current.recording?.chaptersEmbedded ?? null,
     detail,
   }), [recordingCapability.provider]);
+
+  const disableCameraStreamingAtSessionEnd = useCallback(async () => {
+    if (!cameraStreamingControl?.capability.canSetEnabled) {
+      return;
+    }
+
+    try {
+      await cameraStreamingControl.setEnabled(false, { silent: true });
+    } catch (cameraDisableError) {
+      reportClientDiagnostic({
+        category: 'camera_preview_issue',
+        severity: 'warn',
+        message: 'Failed to disable camera streaming at session end.',
+        fingerprint: 'camera-streaming:disable-session-end',
+        details: {
+          error: cameraDisableError,
+          sessionId: sessionRef.current.id,
+        },
+      });
+    }
+  }, [cameraStreamingControl]);
 
   // Background Stopwatch
   useEffect(() => {
@@ -488,6 +511,8 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
       }
     }
 
+    await disableCameraStreamingAtSessionEnd();
+
     onCompleteSession({
       ...recordingSessionSnapshot,
       recording: nextRecording,
@@ -535,6 +560,8 @@ export function ActiveSession({ session: initialSession, initialState, cameraUrl
         setIsRecordingUpdating(false);
       }
     }
+
+    await disableCameraStreamingAtSessionEnd();
 
     onCancel();
   };

--- a/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
+++ b/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
@@ -19,11 +19,14 @@ test('App wires camera streaming control into the dashboard and active session l
 });
 
 
-test('ActiveSession disables camera streaming explicitly when the session ends', () => {
+test('ActiveSession disables camera streaming explicitly when the session ends without blocking completion', () => {
   const activeSession = readFileSync(resolve(process.cwd(), 'src/components/ActiveSession.tsx'), 'utf8');
 
   assert.match(activeSession, /cameraStreamingControl\?: Pick<CameraStreamingControlState, 'capability' \| 'setEnabled'>/);
-  assert.match(activeSession, /await cameraStreamingControl\.setEnabled\(false, \{ silent: true \}\);/);
+  assert.match(activeSession, /cameraStreamingControl\.capability\.enabled !== true/);
+  assert.match(activeSession, /void cameraStreamingControl\.setEnabled\(false, \{ silent: true \}\)\.catch/);
+  assert.doesNotMatch(activeSession, /await cameraStreamingControl\.setEnabled\(false, \{ silent: true \}\);/);
+  assert.doesNotMatch(activeSession, /await disableCameraStreamingAtSessionEnd\(\);/);
   assert.match(activeSession, /Failed to disable camera streaming at session end\./);
 });
 

--- a/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
+++ b/apps/brave-paws-app/tests/camera-streaming-control-ui.test.js
@@ -11,8 +11,20 @@ test('App wires camera streaming control into the dashboard and active session l
   assert.match(app, /currentView === 'active' && Boolean\(activeSession\)/);
   assert.match(app, /pendingSessionCameraStateRef\.current = true/);
   assert.match(app, /pendingSessionCameraStateRef\.current = false/);
+  assert.match(app, /cameraStreamingControl=\{cameraStreamingControl\}/);
+  assert.match(app, /cameraStreamingControl\.isLoading/);
+  assert.match(app, /cameraStreamingControl\.capability\.enabled === pendingState/);
   assert.match(app, /setEnabled\(pendingState, \{ silent: true \}\)/);
-  assert.match(app, /\}, \[activeSession, currentView, cameraStreamingControl\.capability\.canSetEnabled, cameraStreamingControl\.setEnabled\]\);/);
+  assert.match(app, /cameraStreamingControl\.capability\.enabled,/);
+});
+
+
+test('ActiveSession disables camera streaming explicitly when the session ends', () => {
+  const activeSession = readFileSync(resolve(process.cwd(), 'src/components/ActiveSession.tsx'), 'utf8');
+
+  assert.match(activeSession, /cameraStreamingControl\?: Pick<CameraStreamingControlState, 'capability' \| 'setEnabled'>/);
+  assert.match(activeSession, /await cameraStreamingControl\.setEnabled\(false, \{ silent: true \}\);/);
+  assert.match(activeSession, /Failed to disable camera streaming at session end\./);
 });
 
 

--- a/apps/brave-paws-server/README.md
+++ b/apps/brave-paws-server/README.md
@@ -27,6 +27,7 @@ It serves three things from one localhost process:
 | `BRAVE_PAWS_PUBLIC_BASE_URL` | unset | Canonical external base URL used for logs, pairing URLs, and deployment docs |
 | `BRAVE_PAWS_CORS_ALLOWED_ORIGINS` | unset | Comma-separated origin allowlist for cross-origin browser access to the API (for example `https://harvey.cash,https://www.harvey.cash`) |
 | `BRAVE_PAWS_DATA_DIR` | `var/brave-paws` in the repo | Session storage directory (live QUANTUM deploy uses `/mnt/q/fermi/brave-paws/data`) |
+| `BRAVE_PAWS_RECORDINGS_DIR` | `<data dir>/recordings` | Optional canonical recordings directory when session media should live separately from the JSON/CSV session store |
 | `BRAVE_PAWS_AUTH_TOKEN` | unset | Token expected in `x-brave-paws-token` for write requests; required before the HTTP pairing-creation endpoint will mint links |
 | `BRAVE_PAWS_ENABLE_PAIRING` | `false` | Enables the opaque one-time pairing broker |
 | `BRAVE_PAWS_PAIRING_STORE_FILE` | `<data dir>/pairings.json` | Optional override for pairing-token storage |
@@ -51,7 +52,7 @@ It serves three things from one localhost process:
 
 Session data is stored as pretty JSON in `sessions.json` and mirrored to `brave_paws_sessions.csv` in the same directory so it stays easy to inspect, back up, and seed from a manual CSV drop.
 
-When session recording is enabled, finalized media files are expected under `<data dir>/recordings/`, and saved session objects can carry a lightweight `recording` pointer with metadata plus a backend download path.
+When session recording is enabled, finalized media files are expected under `BRAVE_PAWS_RECORDINGS_DIR` when it is set, or `<data dir>/recordings/` otherwise. Saved session objects can carry a lightweight `recording` pointer with metadata plus a backend download path.
 
 When pairing is enabled, opaque one-time camera pairing records are stored separately in `pairings.json`. Those links are meant to bootstrap a browser once; after the app resolves a token, it caches the resulting camera link locally and the token cannot be reused.
 

--- a/apps/brave-paws-server/src/config.ts
+++ b/apps/brave-paws-server/src/config.ts
@@ -105,7 +105,7 @@ export function resolveConfig(env = process.env): BravePawsServerConfig {
     appDistDir: path.resolve(env.BRAVE_PAWS_APP_DIST_DIR || path.join(repoRoot, 'apps', 'brave-paws-app', 'dist')),
     dataDir,
     dataFilePath: path.join(dataDir, 'sessions.json'),
-    recordingsDir: path.join(dataDir, 'recordings'),
+    recordingsDir: path.resolve(env.BRAVE_PAWS_RECORDINGS_DIR || path.join(dataDir, 'recordings')),
     pairingStoreFilePath: path.resolve(env.BRAVE_PAWS_PAIRING_STORE_FILE || path.join(dataDir, 'pairings.json')),
     pairingEnabled: env.BRAVE_PAWS_ENABLE_PAIRING === 'true',
     cameraUpstreamBaseUrl: (env.BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL || 'http://127.0.0.1:18888/').replace(/\/?$/, '/'),

--- a/apps/brave-paws-server/tests/config.test.ts
+++ b/apps/brave-paws-server/tests/config.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveConfig } from '../src/config.ts';
+
+test('resolveConfig defaults recordingsDir under the data dir', () => {
+  const config = resolveConfig({
+    BRAVE_PAWS_DATA_DIR: '/tmp/brave-paws-data',
+  });
+
+  assert.equal(config.dataDir, '/tmp/brave-paws-data');
+  assert.equal(config.recordingsDir, '/tmp/brave-paws-data/recordings');
+});
+
+test('resolveConfig allows recordingsDir to live outside the data dir', () => {
+  const config = resolveConfig({
+    BRAVE_PAWS_DATA_DIR: '/tmp/brave-paws-data',
+    BRAVE_PAWS_RECORDINGS_DIR: '/tmp/brave-paws-archive/recordings',
+  });
+
+  assert.equal(config.dataDir, '/tmp/brave-paws-data');
+  assert.equal(config.recordingsDir, '/tmp/brave-paws-archive/recordings');
+});

--- a/deploy/systemd/brave-paws.service
+++ b/deploy/systemd/brave-paws.service
@@ -13,6 +13,7 @@ Environment=BRAVE_PAWS_PORT=4310
 Environment=BRAVE_PAWS_PUBLIC_BASE_URL=https://quantum.tail080401.ts.net:7447
 Environment="BRAVE_PAWS_CORS_ALLOWED_ORIGINS=https://harvey.cash,https://www.harvey.cash"
 Environment="BRAVE_PAWS_DATA_DIR=/mnt/q/fermi/brave-paws/data"
+Environment="BRAVE_PAWS_RECORDINGS_DIR=/mnt/s/Fermi/Separation Training Sessions/Brave Paws"
 Environment=BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL=http://127.0.0.1:18888/
 Environment=BRAVE_PAWS_CAMERA_CONTROL_PROVIDER=command
 Environment="BRAVE_PAWS_CAMERA_CONTROL_LABEL=Picam streaming"

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -37,6 +37,7 @@ Default bind:
 | `BRAVE_PAWS_PUBLIC_BASE_URL` | `https://quantum.tail080401.ts.net:7447` |
 | `BRAVE_PAWS_CORS_ALLOWED_ORIGINS` | `https://harvey.cash,https://www.harvey.cash` |
 | `BRAVE_PAWS_DATA_DIR` | `/mnt/q/fermi/brave-paws/data` |
+| `BRAVE_PAWS_RECORDINGS_DIR` | `/mnt/s/Fermi/Separation Training Sessions/Brave Paws` |
 | `BRAVE_PAWS_AUTH_TOKEN` | `replace-with-long-random-secret-before-enabling-pairing` |
 | `BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL` | `http://127.0.0.1:18888/` |
 | `BRAVE_PAWS_CAMERA_CONTROL_PROVIDER` | `command` |
@@ -56,6 +57,8 @@ QUANTUM keeps a canonical JSON store plus a mirrored CSV export in the same data
 - `${BRAVE_PAWS_DATA_DIR}/brave_paws_sessions.csv`
 
 If Harvey drops a fresher `brave_paws_sessions.csv` into the data folder, the server ingests it on the next read and rewrites the canonical JSON store.
+
+Session recordings live separately under `${BRAVE_PAWS_RECORDINGS_DIR}` so the media archive sits on `S:` while the lighter session JSON/CSV store stays on `Q:`.
 
 ## API surface
 


### PR DESCRIPTION
## Summary
- move Brave Paws recordings onto the S: archive via `BRAVE_PAWS_RECORDINGS_DIR`
- explicitly disable picam streaming when an active session completes or is cancelled
- cover the new config and session-end camera behavior with tests/docs

## Verification
- npm --prefix apps/brave-paws-app test -- tests/camera-streaming-control-ui.test.js
- npm --prefix apps/brave-paws-server test -- tests/cameraControl.test.ts tests/config.test.ts
- npm --prefix apps/brave-paws-app run build
- npm --prefix apps/brave-paws-server run build
- moved existing recordings from `/mnt/q/fermi/brave-paws/data/recordings` to `/mnt/s/Fermi/Separation Training Sessions/Brave Paws`
