### PR TITLE
Recover Brave Paws recording stop results and add readable archive names

### DIFF
--- a/apps/brave-paws-app/src/utils/backendCapabilities.ts
+++ b/apps/brave-paws-app/src/utils/backendCapabilities.ts
@@ -1,6 +1,6 @@
 import { getApiBaseUrl } from '../config';
 import type { Session, SessionRecording, SessionTimelineEvent } from '../types';
-import { parseBackendJsonResponse } from './backendRequests';
+import { isBackendUnavailableError, parseBackendJsonResponse } from './backendRequests';
 
 export type CameraStreamingCapability = {
   key: 'cameraStreaming';
@@ -101,6 +101,22 @@ export async function startSessionRecording(
   return parseBackendJsonResponse<SessionRecordingCapability>(response);
 }
 
+const STOP_RECORDING_RETRY_DELAYS_MS = [250, 750] as const;
+
+function isRetryableStopRecordingError(error: unknown): boolean {
+  if (isBackendUnavailableError(error)) {
+    return true;
+  }
+
+  return error instanceof TypeError;
+}
+
+function waitForRetry(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
 export async function stopSessionRecording(
   payload: {
     sessionId: string;
@@ -111,13 +127,27 @@ export async function stopSessionRecording(
   fetchImpl: typeof fetch = fetch,
   apiBaseUrl = getApiBaseUrl(),
 ): Promise<SessionRecordingCapability> {
-  const response = await fetchImpl(`${apiBaseUrl}recording/stop`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  });
+  let lastError: unknown = null;
 
-  return parseBackendJsonResponse<SessionRecordingCapability>(response);
+  for (let attempt = 0; attempt <= STOP_RECORDING_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      const response = await fetchImpl(`${apiBaseUrl}recording/stop`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      return parseBackendJsonResponse<SessionRecordingCapability>(response);
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableStopRecordingError(error) || attempt === STOP_RECORDING_RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+      await waitForRetry(STOP_RECORDING_RETRY_DELAYS_MS[attempt]!);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('Unable to stop session recording');
 }

--- a/apps/brave-paws-app/tests/backend-capabilities.test.ts
+++ b/apps/brave-paws-app/tests/backend-capabilities.test.ts
@@ -183,6 +183,47 @@ test('fetchBackendCapabilities reports invalid non-HTML JSON payloads as unexpec
   );
 });
 
+test('stopSessionRecording retries transient fetch failures and returns the recovered stop result', async () => {
+  let attempts = 0;
+  const capability = await stopSessionRecording(
+    {
+      sessionId: 'session-abc',
+      disposition: 'save',
+    },
+    (async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw new TypeError('Failed to fetch');
+      }
+
+      return new Response(JSON.stringify({
+        ...UNSUPPORTED_SESSION_RECORDING_CAPABILITY,
+        supported: true,
+        canStart: true,
+        canStop: true,
+        active: false,
+        sessionId: 'session-abc',
+        provider: 'command',
+        recording: {
+          status: 'completed',
+          sessionId: 'session-abc',
+          provider: 'command',
+          relativeFilePath: '2026/05/09/2026-05-09 18-00-00 - max 12m.mp4',
+        },
+        detail: null,
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch,
+    'https://brave-paws.example/separation/api/',
+  );
+
+  assert.equal(attempts, 3);
+  assert.equal(capability.recording?.status, 'completed');
+  assert.equal(capability.recording?.relativeFilePath, '2026/05/09/2026-05-09 18-00-00 - max 12m.mp4');
+});
+
 test('stopSessionRecording posts the stop payload to the recording stop endpoint', async () => {
   const capability = await stopSessionRecording(
     {

--- a/apps/brave-paws-server/src/recordingControl.ts
+++ b/apps/brave-paws-server/src/recordingControl.ts
@@ -1,4 +1,6 @@
 import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { promisify } from 'node:util';
 
 import type { BravePawsServerConfig } from './config.js';
@@ -254,15 +256,55 @@ function buildCapability(options: {
   };
 }
 
+function getSessionMaxDurationSeconds(payload: RecordingCommandPayload): number | null {
+  if (!payload.sessionSnapshot?.steps.length) {
+    return null;
+  }
+
+  const total = payload.sessionSnapshot.steps.reduce((sum, step) => sum + Math.max(0, step.durationSeconds), 0);
+  return Number.isFinite(total) ? total : null;
+}
+
 function buildRecordingEnv(config: BravePawsServerConfig, payload: RecordingCommandPayload = {}): Record<string, string> {
+  const sessionMaxDurationSeconds = getSessionMaxDurationSeconds(payload);
   return {
     BRAVE_PAWS_DATA_DIR: config.dataDir,
     BRAVE_PAWS_RECORDINGS_DIR: config.recordingsDir,
     BRAVE_PAWS_RECORDING_SESSION_ID: payload.sessionId || '',
     BRAVE_PAWS_RECORDING_SESSION_DATE: payload.sessionDate || '',
     BRAVE_PAWS_RECORDING_SESSION_STATUS: payload.sessionStatus || '',
+    BRAVE_PAWS_RECORDING_SESSION_MAX_DURATION_SECONDS: sessionMaxDurationSeconds == null ? '' : String(sessionMaxDurationSeconds),
     BRAVE_PAWS_RECORDING_DISPOSITION: payload.disposition || 'save',
   };
+}
+
+function getStopResultCacheFilePath(config: BravePawsServerConfig, sessionId: string): string {
+  return path.join(config.dataDir, 'recording-stop-cache', `${sessionId}.json`);
+}
+
+async function readCachedStopCapability(options: {
+  config: BravePawsServerConfig;
+  sessionId: string;
+  label: string;
+  provider: string;
+}): Promise<SessionRecordingCapability | null> {
+  try {
+    const raw = await fs.readFile(getStopResultCacheFilePath(options.config, options.sessionId), 'utf8');
+    const capability = parseCapabilityOutput(raw, options.label, options.provider);
+    return capability.sessionId === options.sessionId ? capability : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCachedStopCapability(options: {
+  config: BravePawsServerConfig;
+  sessionId: string;
+  capability: SessionRecordingCapability;
+}): Promise<void> {
+  const cacheFilePath = getStopResultCacheFilePath(options.config, options.sessionId);
+  await fs.mkdir(path.dirname(cacheFilePath), { recursive: true });
+  await fs.writeFile(cacheFilePath, `${JSON.stringify(options.capability)}\n`, 'utf8');
 }
 
 class UnsupportedSessionRecordingController implements SessionRecordingController {
@@ -364,6 +406,18 @@ class CommandSessionRecordingController implements SessionRecordingController {
 
   async stopRecording(payload: RecordingCommandPayload): Promise<SessionRecordingCapability> {
     return this.runExclusive(async () => {
+      if (payload.sessionId) {
+        const cachedCapability = await readCachedStopCapability({
+          config: this.options.config,
+          sessionId: payload.sessionId,
+          label: this.options.label,
+          provider: this.options.provider,
+        });
+        if (cachedCapability) {
+          return cachedCapability;
+        }
+      }
+
       try {
         const result = await runShellCommand(
           this.options.stopCommand,
@@ -371,26 +425,35 @@ class CommandSessionRecordingController implements SessionRecordingController {
           buildRecordingEnv(this.options.config, payload),
         );
         const capability = parseCapabilityOutput(result.stdout, this.options.label, this.options.provider);
-        if (!capability.recording || payload.disposition === 'discard') {
-          return capability;
+
+        let resolvedCapability = capability;
+        if (capability.recording && payload.disposition !== 'discard') {
+          try {
+            const finalizedRecording = await finalizeRecordingMetadata({
+              config: this.options.config,
+              recording: capability.recording,
+              sessionSnapshot: payload.sessionSnapshot,
+              timelineEvents: payload.timelineEvents,
+            });
+
+            resolvedCapability = {
+              ...capability,
+              recording: finalizedRecording,
+            };
+          } catch (metadataError) {
+            console.warn('Session recording metadata finalization failed.', metadataError);
+          }
         }
 
-        try {
-          const finalizedRecording = await finalizeRecordingMetadata({
+        if (payload.sessionId && !resolvedCapability.active) {
+          await writeCachedStopCapability({
             config: this.options.config,
-            recording: capability.recording,
-            sessionSnapshot: payload.sessionSnapshot,
-            timelineEvents: payload.timelineEvents,
+            sessionId: payload.sessionId,
+            capability: resolvedCapability,
           });
-
-          return {
-            ...capability,
-            recording: finalizedRecording,
-          };
-        } catch (metadataError) {
-          console.warn('Session recording metadata finalization failed.', metadataError);
-          return capability;
         }
+
+        return resolvedCapability;
       } catch (error) {
         console.error('Session recording stop command failed', error);
         return this.readCapability(payload, getSafeCommandErrorDetail(error, getCommandFailureDetail('stop')));

--- a/apps/brave-paws-server/src/recordingControl.ts
+++ b/apps/brave-paws-server/src/recordingControl.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -278,8 +279,26 @@ function buildRecordingEnv(config: BravePawsServerConfig, payload: RecordingComm
   };
 }
 
+function getStopResultCacheKey(sessionId: string): string {
+  return createHash('sha256').update(sessionId).digest('hex');
+}
+
 function getStopResultCacheFilePath(config: BravePawsServerConfig, sessionId: string): string {
-  return path.join(config.dataDir, 'recording-stop-cache', `${sessionId}.json`);
+  return path.join(config.dataDir, 'recording-stop-cache', `${getStopResultCacheKey(sessionId)}.json`);
+}
+
+async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  const directoryPath = path.dirname(filePath);
+  await fs.mkdir(directoryPath, { recursive: true });
+
+  const tempFilePath = path.join(directoryPath, `${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    await fs.writeFile(tempFilePath, content, 'utf8');
+    await fs.rename(tempFilePath, filePath);
+  } catch (error) {
+    await fs.rm(tempFilePath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 async function readCachedStopCapability(options: {
@@ -303,8 +322,7 @@ async function writeCachedStopCapability(options: {
   capability: SessionRecordingCapability;
 }): Promise<void> {
   const cacheFilePath = getStopResultCacheFilePath(options.config, options.sessionId);
-  await fs.mkdir(path.dirname(cacheFilePath), { recursive: true });
-  await fs.writeFile(cacheFilePath, `${JSON.stringify(options.capability)}\n`, 'utf8');
+  await writeFileAtomic(cacheFilePath, `${JSON.stringify(options.capability)}\n`);
 }
 
 class UnsupportedSessionRecordingController implements SessionRecordingController {

--- a/apps/brave-paws-server/src/recordingMetadata.ts
+++ b/apps/brave-paws-server/src/recordingMetadata.ts
@@ -87,6 +87,121 @@ function normalizeTimestamp(value: unknown): string | null {
   return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
 }
 
+function formatRecordingFilenameTimestamp(value: string | null | undefined): string | null {
+  if (typeof value !== 'string' || !value.trim() || !Number.isFinite(Date.parse(value))) {
+    return null;
+  }
+
+  const match = value.trim().match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
+  if (!match) {
+    return null;
+  }
+
+  const [, year, month, day, hour, minute, second] = match;
+  return `${year}-${month}-${day} ${hour}-${minute}-${second}`;
+}
+
+function formatRecordingFilenameDuration(durationSeconds: number | null): string | null {
+  if (durationSeconds == null || !Number.isFinite(durationSeconds) || durationSeconds < 0) {
+    return null;
+  }
+
+  const totalSeconds = Math.round(durationSeconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts: string[] = [];
+
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+
+  if (minutes > 0 || hours > 0) {
+    parts.push(hours > 0 && seconds > 0 && minutes < 10 ? `${minutes}m` : `${minutes}m`);
+  }
+
+  if (seconds > 0 || (!hours && !minutes)) {
+    parts.push(`${seconds}s`);
+  }
+
+  return parts.join('');
+}
+
+function getPlannedSessionDurationSeconds(sessionSnapshot: Session | null | undefined): number | null {
+  if (!sessionSnapshot?.steps.length) {
+    return null;
+  }
+
+  const total = sessionSnapshot.steps.reduce((sum, step) => sum + Math.max(0, step.durationSeconds), 0);
+  return Number.isFinite(total) ? total : null;
+}
+
+function sanitizeRecordingFilenameComponent(value: string): string {
+  return value
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function moveFile(sourcePath: string, targetPath: string): Promise<void> {
+  try {
+    await fs.rename(sourcePath, targetPath);
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error ? (error as { code?: string }).code : null;
+    if (code !== 'EXDEV') {
+      throw error;
+    }
+
+    await fs.copyFile(sourcePath, targetPath);
+    await fs.unlink(sourcePath);
+  }
+}
+
+async function buildPreferredRelativeRecordingPath(options: {
+  config: BravePawsServerConfig;
+  recording: SessionRecording;
+  currentRelativePath: string;
+  sessionSnapshot?: Session | null;
+}): Promise<string | null> {
+  const timestampLabel = formatRecordingFilenameTimestamp(options.recording.startedAt ?? options.recording.stoppedAt ?? null);
+  if (!timestampLabel) {
+    return null;
+  }
+
+  const extension = path.posix.extname(options.currentRelativePath) || '.mp4';
+  const dirname = path.posix.dirname(options.currentRelativePath);
+  const durationLabel = formatRecordingFilenameDuration(getPlannedSessionDurationSeconds(options.sessionSnapshot));
+  const preferredBasename = sanitizeRecordingFilenameComponent(
+    durationLabel ? `${timestampLabel} - max ${durationLabel}` : timestampLabel,
+  );
+  const baseRelativePath = dirname === '.'
+    ? `${preferredBasename}${extension}`
+    : path.posix.join(dirname, `${preferredBasename}${extension}`);
+
+  if (baseRelativePath === options.currentRelativePath) {
+    return baseRelativePath;
+  }
+
+  const baseResolvedPath = path.join(options.config.recordingsDir, ...baseRelativePath.split('/'));
+  if (!await pathExists(baseResolvedPath)) {
+    return baseRelativePath;
+  }
+
+  const sessionSuffix = options.recording.sessionId?.slice(0, 8) ?? 'recording';
+  return dirname === '.'
+    ? `${preferredBasename} - ${sessionSuffix}${extension}`
+    : path.posix.join(dirname, `${preferredBasename} - ${sessionSuffix}${extension}`);
+}
+
 function normalizeStepStatus(value: unknown): StepStatus | null {
   return STEP_STATUSES.has(value as StepStatus) ? (value as StepStatus) : null;
 }
@@ -557,9 +672,33 @@ export async function finalizeRecordingMetadata(options: {
     return recording;
   }
 
-  const resolvedPaths = resolveSafeRelativeRecordingPath(options.config, recording.relativeFilePath);
+  let workingRecording = recording;
+  let resolvedPaths = resolveSafeRelativeRecordingPath(options.config, workingRecording.relativeFilePath!);
   if (!resolvedPaths) {
     return recording;
+  }
+
+  const preferredRelativePath = await buildPreferredRelativeRecordingPath({
+    config: options.config,
+    recording: workingRecording,
+    currentRelativePath: resolvedPaths.safeRelativePath,
+    sessionSnapshot: options.sessionSnapshot,
+  });
+
+  if (preferredRelativePath && preferredRelativePath !== resolvedPaths.safeRelativePath) {
+    const preferredResolvedPaths = resolveSafeRelativeRecordingPath(options.config, preferredRelativePath);
+    if (preferredResolvedPaths) {
+      await fs.mkdir(path.dirname(preferredResolvedPaths.resolvedRecordingPath), { recursive: true });
+      await moveFile(resolvedPaths.resolvedRecordingPath, preferredResolvedPaths.resolvedRecordingPath);
+      if (preferredResolvedPaths.metadataFilePath !== resolvedPaths.metadataFilePath) {
+        await fs.rm(resolvedPaths.metadataFilePath, { force: true });
+      }
+      workingRecording = {
+        ...workingRecording,
+        relativeFilePath: preferredResolvedPaths.safeRelativePath,
+      };
+      resolvedPaths = preferredResolvedPaths;
+    }
   }
 
   const { resolvedRecordingPath, metadataRelativePath, metadataFilePath, safeRelativePath } = resolvedPaths;
@@ -570,7 +709,7 @@ export async function finalizeRecordingMetadata(options: {
   const measuredSizeBytes = recording.sizeBytes ?? await readFileSize(resolvedRecordingPath);
   const measuredDurationSeconds = recording.durationSeconds ?? await probeMediaDurationSeconds(resolvedRecordingPath);
   const nextRecording: SessionRecording = {
-    ...recording,
+    ...workingRecording,
     sizeBytes: measuredSizeBytes,
     durationSeconds: measuredDurationSeconds,
     metadataRelativeFilePath: metadataRelativePath,
@@ -585,7 +724,7 @@ export async function finalizeRecordingMetadata(options: {
   });
 
   let chaptersEmbedded = false;
-  if (path.extname(resolvedRecordingPath).toLowerCase() === '.mp4') {
+  if (nextRecording.durationSeconds != null && path.extname(resolvedRecordingPath).toLowerCase() === '.mp4') {
     try {
       chaptersEmbedded = await embedChaptersIntoMp4(resolvedRecordingPath, chapters);
     } catch (error) {

--- a/apps/brave-paws-server/src/recordingMetadata.ts
+++ b/apps/brave-paws-server/src/recordingMetadata.ts
@@ -117,7 +117,7 @@ function formatRecordingFilenameDuration(durationSeconds: number | null): string
   }
 
   if (minutes > 0 || hours > 0) {
-    parts.push(hours > 0 && seconds > 0 && minutes < 10 ? `${minutes}m` : `${minutes}m`);
+    parts.push(`${minutes}m`);
   }
 
   if (seconds > 0 || (!hours && !minutes)) {

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -333,10 +333,10 @@ test('session recording capability can be started and stopped through the comman
       assert.equal(stopped.active, false);
       assert.equal(stopped.sessionId, 'session-123');
       assert.equal(stopped.recording?.status, 'completed');
-      assert.equal(stopped.recording?.relativeFilePath, '2026/05/09/session-123.mp4');
-      assert.equal(stopped.recording?.downloadPath, '/separation/api/recordings/file/2026/05/09/session-123.mp4');
-      assert.equal(stopped.recording?.metadataRelativeFilePath, '2026/05/09/session-123.brave-paws.json');
-      assert.equal(stopped.recording?.metadataDownloadPath, '/separation/api/recordings/file/2026/05/09/session-123.brave-paws.json');
+      assert.equal(stopped.recording?.relativeFilePath, '2026/05/09/2026-05-09 18-00-00 - max 12m.mp4');
+      assert.equal(stopped.recording?.downloadPath, '/separation/api/recordings/file/2026/05/09/2026-05-09%2018-00-00%20-%20max%2012m.mp4');
+      assert.equal(stopped.recording?.metadataRelativeFilePath, '2026/05/09/2026-05-09 18-00-00 - max 12m.brave-paws.json');
+      assert.equal(stopped.recording?.metadataDownloadPath, '/separation/api/recordings/file/2026/05/09/2026-05-09%2018-00-00%20-%20max%2012m.brave-paws.json');
       assert.equal(stopped.recording?.chapterCount, 2);
       assert.equal(stopped.recording?.chaptersEmbedded, false);
 
@@ -344,10 +344,10 @@ test('session recording capability can be started and stopped through the comman
       assert.equal(servedRecording.status, 200);
       assert.equal(await servedRecording.text(), 'fake recording payload');
 
-      const storedRecordingPath = path.join(config.recordingsDir, '2026/05/09/session-123.mp4');
+      const storedRecordingPath = path.join(config.recordingsDir, '2026/05/09/2026-05-09 18-00-00 - max 12m.mp4');
       assert.equal(await fs.readFile(storedRecordingPath, 'utf8'), 'fake recording payload');
 
-      const storedMetadataPath = path.join(config.recordingsDir, '2026/05/09/session-123.brave-paws.json');
+      const storedMetadataPath = path.join(config.recordingsDir, '2026/05/09/2026-05-09 18-00-00 - max 12m.brave-paws.json');
       const sidecar = JSON.parse(await fs.readFile(storedMetadataPath, 'utf8')) as {
         version: number;
         recordingFile: { metadataRelativePath: string; relativePath: string };
@@ -356,8 +356,8 @@ test('session recording capability can be started and stopped through the comman
         chapters: Array<{ title: string }>;
       };
       assert.equal(sidecar.version, 1);
-      assert.equal(sidecar.recordingFile.relativePath, '2026/05/09/session-123.mp4');
-      assert.equal(sidecar.recordingFile.metadataRelativePath, '2026/05/09/session-123.brave-paws.json');
+      assert.equal(sidecar.recordingFile.relativePath, '2026/05/09/2026-05-09 18-00-00 - max 12m.mp4');
+      assert.equal(sidecar.recordingFile.metadataRelativePath, '2026/05/09/2026-05-09 18-00-00 - max 12m.brave-paws.json');
       assert.equal(sidecar.recording.chapterCount, 2);
       assert.equal(sidecar.recording.chaptersEmbedded, false);
       assert.equal(sidecar.timeline.eventCount, 4);
@@ -368,6 +368,65 @@ test('session recording capability can be started and stopped through the comman
       recordingStatusCommand: `python3 - <<'PY'\nimport json, os\nstate_file = ${JSON.stringify(stateFilePath)}\nif not os.path.exists(state_file):\n    print(json.dumps({"active": False, "sessionId": None, "recording": None}))\nelse:\n    print(open(state_file, 'r', encoding='utf8').read())\nPY`,
       recordingStartCommand: `python3 - <<'PY'\nimport json, os\nstate_file = ${JSON.stringify(stateFilePath)}\npayload = {"active": True, "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "recording": {"status": "recording", "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "startedAt": "2026-05-09T18:00:00.000Z", "hasAudio": True}}\nos.makedirs(os.path.dirname(state_file), exist_ok=True)\nopen(state_file, 'w', encoding='utf8').write(json.dumps(payload))\nprint(json.dumps(payload))\nPY`,
       recordingStopCommand: `python3 - <<'PY'\nimport json, os\nstate_file = ${JSON.stringify(stateFilePath)}\npayload = {"active": False, "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "recording": {"status": "completed", "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "startedAt": "2026-05-09T18:00:00.000Z", "stoppedAt": "2026-05-09T18:12:00.000Z", "hasAudio": True, "relativeFilePath": "2026/05/09/session-123.mp4", "durationSeconds": 720, "sizeBytes": 19}}\nos.makedirs(os.path.dirname(state_file), exist_ok=True)\nopen(state_file, 'w', encoding='utf8').write(json.dumps(payload))\nprint(json.dumps(payload))\nPY`,
+    });
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('session recording stop replays a cached completed result for the same session id', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'brave-paws-recording-stop-cache-'));
+  const stopCountFilePath = path.join(tempDir, 'stop-count.txt');
+  const recordingDir = path.join(tempDir, 'recordings');
+
+  try {
+    await withFixtureServer(async ({ baseUrl }) => {
+      const recordingSourcePath = path.join(recordingDir, '2026/05/09/session-123.mp4');
+      await fs.mkdir(path.dirname(recordingSourcePath), { recursive: true });
+      await fs.writeFile(recordingSourcePath, 'fake recording payload');
+
+      const payload = {
+        sessionId: 'session-123',
+        disposition: 'save',
+        sessionSnapshot: {
+          id: 'session-123',
+          date: '2026-05-09T18:00:00.000Z',
+          totalDurationSeconds: 720,
+          status: 'completed' as const,
+          steps: [
+            { id: 'step-1', durationSeconds: 30, status: 'completed' as const },
+            { id: 'step-2', durationSeconds: 690, status: 'completed' as const },
+          ],
+        },
+      };
+
+      const firstResponse = await fetch(`${baseUrl}/separation/api/recording/stop`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      assert.equal(firstResponse.status, 200);
+
+      const secondResponse = await fetch(`${baseUrl}/separation/api/recording/stop`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      assert.equal(secondResponse.status, 200);
+
+      const secondBody = await secondResponse.json() as {
+        sessionId: string | null;
+        recording: { relativeFilePath: string | null } | null;
+      };
+      assert.equal(secondBody.sessionId, 'session-123');
+      assert.equal(secondBody.recording?.relativeFilePath, '2026/05/09/2026-05-09 18-00-00 - max 12m.mp4');
+      assert.equal((await fs.readFile(stopCountFilePath, 'utf8')).trim(), '1');
+    }, {
+      recordingProvider: 'command',
+      recordingsDir: recordingDir,
+      recordingStatusCommand: `python3 - <<'PY'\nimport json\nprint(json.dumps({"active": False, "sessionId": None, "recording": None}))\nPY`,
+      recordingStartCommand: `python3 - <<'PY'\nimport json\nprint(json.dumps({"active": True, "sessionId": "session-123", "recording": {"status": "recording", "sessionId": "session-123", "provider": "command"}}))\nPY`,
+      recordingStopCommand: `python3 - <<'PY'\nimport json, os\ncount_file = ${JSON.stringify(stopCountFilePath)}\ncount = 0\nif os.path.exists(count_file):\n    count = int(open(count_file, 'r', encoding='utf8').read().strip() or '0')\ncount += 1\nos.makedirs(os.path.dirname(count_file), exist_ok=True)\nopen(count_file, 'w', encoding='utf8').write(str(count))\npayload = {"active": False, "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "recording": {"status": "completed", "sessionId": os.environ.get("BRAVE_PAWS_RECORDING_SESSION_ID"), "startedAt": "2026-05-09T18:00:00.000Z", "stoppedAt": "2026-05-09T18:12:00.000Z", "hasAudio": True, "relativeFilePath": "2026/05/09/session-123.mp4", "durationSeconds": 720, "sizeBytes": 19}}\nprint(json.dumps(payload))\nPY`,
     });
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });

--- a/deploy/scripts/brave-paws-picam-recording-control.sh
+++ b/deploy/scripts/brave-paws-picam-recording-control.sh
@@ -149,6 +149,36 @@ clear_state() {
   rm -f "$STATE_FILE"
 }
 
+session_result_path() {
+  local session_id="$1"
+  printf '%s\n' "$SESSIONS_DIR/$session_id/result.json"
+}
+
+write_session_result() {
+  local session_id="$1"
+  local payload="$2"
+  local result_path
+  result_path="$(session_result_path "$session_id")"
+  mkdir -p "$(dirname "$result_path")"
+  printf '%s\n' "$payload" >"$result_path"
+}
+
+print_saved_session_result() {
+  local session_id="$1"
+  if [[ -z "$session_id" ]]; then
+    return 1
+  fi
+
+  local result_path
+  result_path="$(session_result_path "$session_id")"
+  if [[ ! -f "$result_path" ]]; then
+    return 1
+  fi
+
+  cat "$result_path"
+  return 0
+}
+
 is_pid_alive() {
   local pid="$1"
   [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
@@ -277,8 +307,10 @@ start_recording() {
   local mkv_path="$session_dir/capture.mkv"
   local mp4_path="$session_dir/final.mp4"
   local log_path="$session_dir/ffmpeg.log"
+  local result_path
+  result_path="$(session_result_path "$SESSION_ID")"
   mkdir -p "$session_dir"
-  rm -f "$mkv_path" "$mp4_path"
+  rm -f "$mkv_path" "$mp4_path" "$result_path"
 
   local has_audio="false"
   if ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$RTSP_URL" 2>/dev/null | grep -q '^audio$'; then
@@ -314,6 +346,9 @@ stop_recording() {
   load_state
 
   if [[ -z "$STATE_SESSION_ID" ]]; then
+    if print_saved_session_result "$SESSION_ID"; then
+      return
+    fi
     status_json
     return
   fi
@@ -443,9 +478,8 @@ PY
 
   local size_bytes
   size_bytes="$(stat -c '%s' "$remote_file")"
-  clear_state
-
-  json_out \
+  local completed_payload
+  completed_payload="$(json_out \
     key '"sessionRecording"' \
     label '"Session recording"' \
     provider '"command"' \
@@ -473,7 +507,10 @@ print(json.dumps({
   'detail': sys.argv[8] or None,
 }))
 PY
-)"
+)")"
+  clear_state
+  write_session_result "$session_id" "$completed_payload"
+  echo "$completed_payload"
 }
 
 case "$MODE" in

--- a/deploy/scripts/brave-paws-picam-recording-control.sh
+++ b/deploy/scripts/brave-paws-picam-recording-control.sh
@@ -158,9 +158,14 @@ write_session_result() {
   local session_id="$1"
   local payload="$2"
   local result_path
+  local result_dir
+  local temp_path
   result_path="$(session_result_path "$session_id")"
-  mkdir -p "$(dirname "$result_path")"
-  printf '%s\n' "$payload" >"$result_path"
+  result_dir="$(dirname "$result_path")"
+  mkdir -p "$result_dir"
+  temp_path="$result_dir/.result.$$.tmp"
+  printf '%s\n' "$payload" >"$temp_path"
+  mv -f "$temp_path" "$result_path"
 }
 
 print_saved_session_result() {


### PR DESCRIPTION
## Summary
- cache and replay successful recording-stop results so a transient client/network fetch failure can still be retried safely without losing the completed archive metadata
- rename completed Brave Paws recordings and sidecars to human-readable `YYYY-MM-DD HH-MM-SS - max <duration>` filenames based on the session start time and planned max duration
- add client/server/script coverage for retrying transient stop failures and replaying the saved stop result from the picam recording control script

## Testing
- npm test
- npm run lint