### PR TITLE
feat: add Brave Paws version sync and release follower

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Recommended layout on QUARK:
 - dedicated live clone: `~/services/separation-tracker-live`
 - live backend service: `brave-paws.service`
 - release-follow timer: `brave-paws-cd-sync.timer`
+- canonical live unit source: `deploy/systemd/brave-paws.live.service`
 
 Install the sync timer from the live clone:
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,35 @@ Historical context:
 - `docs/plans/` contains planning and implementation-brief docs kept for rationale and project history. Prefer the docs above for current operational behavior.
 - checklist-style docs under `docs/` are usually point-in-time implementation records rather than ongoing runbooks.
 
+## Live QUARK backend release-follow sync
+
+Brave Paws can now follow the latest successful `main` release on QUARK in the same style as `harvey-dashboard`.
+
+Recommended layout on QUARK:
+
+- dedicated live clone: `~/services/separation-tracker-live`
+- live backend service: `brave-paws.service`
+- release-follow timer: `brave-paws-cd-sync.timer`
+
+Install the sync timer from the live clone:
+
+```bash
+sudo ~/services/separation-tracker-live/deploy/scripts/install-brave-paws-cd-sync-timer.sh
+```
+
+What it does:
+
+- fetches tags from `harvey-cash/separation-tracker` and selects the highest `vX.Y.Z` release tag
+- switches the live clone to `main`
+- hard-resets to that release-tag commit
+- runs `npm ci`
+- rebuilds Brave Paws
+- reinstalls the canonical `brave-paws.service` unit from the live clone
+- restarts `brave-paws.service`
+- records the applied release in `~/.local/state/brave-paws/cd-sync-state.json`
+
+This gives QUARK a durable post-CD update path without relying on direct GitHub Actions access into the host.
+
 ## Notes
 
 - Browser-local persistence remains first-class, with automatic backend hydration/push around it.

--- a/apps/brave-paws-app/src/App.tsx
+++ b/apps/brave-paws-app/src/App.tsx
@@ -16,7 +16,7 @@ import { useCameraStreamingControl } from './hooks/useCameraStreamingControl';
 import { useStorageSync } from './hooks/useStorageSync';
 import { exportToCSV, parseCSV } from './utils/export';
 import { CAMERA_URL_STORAGE_KEY, getCameraUrlFromSearch } from './utils/cameraUrl';
-import { loadStoredBackendRootUrl } from './config';
+import { getApiBaseUrl, loadStoredBackendRootUrl } from './config';
 import { buildNewSessionSteps, loadAppSettings, saveAppSettings } from './settings';
 import { PAIRING_TOKEN_QUERY_PARAM, resolveCameraUrlFromPairingToken } from './utils/pairingToken';
 import { installGlobalClientDiagnostics } from './utils/clientDiagnostics';
@@ -51,6 +51,7 @@ export default function App() {
   const [backendRootUrl, setBackendRootUrl] = useState<string | null>(() => loadStoredBackendRootUrl());
   const [appSettings, setAppSettings] = useState(() => loadAppSettings());
   const cameraStreamingControl = useCameraStreamingControl();
+  const [backendVersion, setBackendVersion] = useState<string | null>(null);
   const wasTrainingActiveRef = useRef(false);
   const pendingSessionCameraStateRef = useRef<boolean | null>(restoredActiveSessionState ? true : null);
 
@@ -88,6 +89,52 @@ export default function App() {
     };
 
     void applyPairingFromLocation();
+  }, [backendRootUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const healthUrl = `${getApiBaseUrl()}health`;
+
+    const refreshBackendVersion = async () => {
+      try {
+        const response = await fetch(healthUrl, { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`Backend health check failed (${response.status})`);
+        }
+
+        const payload = await response.json() as { version?: string };
+        if (!cancelled) {
+          setBackendVersion(typeof payload.version === 'string' && payload.version ? payload.version : null);
+        }
+      } catch {
+        if (!cancelled) {
+          setBackendVersion(null);
+        }
+      }
+    };
+
+    void refreshBackendVersion();
+
+    const handleResume = () => {
+      if (document.visibilityState === 'hidden') {
+        return;
+      }
+
+      void refreshBackendVersion();
+    };
+
+    window.addEventListener('focus', handleResume);
+    window.addEventListener('online', handleResume);
+    window.addEventListener('pageshow', handleResume);
+    document.addEventListener('visibilitychange', handleResume);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('focus', handleResume);
+      window.removeEventListener('online', handleResume);
+      window.removeEventListener('pageshow', handleResume);
+      document.removeEventListener('visibilitychange', handleResume);
+    };
   }, [backendRootUrl]);
 
   // Keep cameraUrl in sync with local storage
@@ -235,6 +282,7 @@ export default function App() {
             />
           }
           isBackendUnavailable={!storageSync.provider.isAvailable}
+          backendVersion={backendVersion}
         />
       )}
 

--- a/apps/brave-paws-app/src/components/BackendConnectionSettings.tsx
+++ b/apps/brave-paws-app/src/components/BackendConnectionSettings.tsx
@@ -14,6 +14,7 @@ type Props = {
   currentBackendRootUrl: string | null;
   isBackendAvailable: boolean;
   onBackendRootUrlChange: (backendRootUrl: string | null) => void;
+  onBackendVersionChange?: (backendVersion: string | null) => void;
 };
 
 type ConnectionStatus = 'idle' | 'testing' | 'saved' | 'error';
@@ -22,6 +23,7 @@ export function BackendConnectionSettings({
   currentBackendRootUrl,
   isBackendAvailable,
   onBackendRootUrlChange,
+  onBackendVersionChange,
 }: Props) {
   const [draftValue, setDraftValue] = useState(currentBackendRootUrl || '');
   const [status, setStatus] = useState<ConnectionStatus>('idle');
@@ -61,6 +63,9 @@ export function BackendConnectionSettings({
         throw new Error(`Backend health check failed (${response.status})`);
       }
 
+      const healthPayload = await response.json() as { version?: string };
+      onBackendVersionChange?.(typeof healthPayload.version === 'string' && healthPayload.version ? healthPayload.version : null);
+
       const saved = saveStoredBackendRootUrl(normalized);
       onBackendRootUrlChange(saved);
       setDraftValue(saved || normalized);
@@ -75,6 +80,7 @@ export function BackendConnectionSettings({
   const handleReset = () => {
     clearStoredBackendRootUrl();
     onBackendRootUrlChange(null);
+    onBackendVersionChange?.(null);
     setDraftValue('');
     setStatus('idle');
     setMessage('Reset to the deployment default backend.');

--- a/apps/brave-paws-app/src/components/Dashboard.tsx
+++ b/apps/brave-paws-app/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { Session } from '../types';
 import { formatDuration } from '../utils/format';
-import { Play, BarChart2, History, Heart, Info, Server, Settings } from 'lucide-react';
+import { AlertTriangle, Play, BarChart2, History, Heart, Info, Server, Settings } from 'lucide-react';
 import { format } from 'date-fns';
 import { ReactNode } from 'react';
 import { getAbortedStepCount, getCompletedStepCount, getRecordedStepDurationSeconds } from '../utils/sessionStatus';
@@ -16,6 +16,8 @@ type Props = {
   cameraStreamingControl?: ReactNode;
   storageSync?: ReactNode;
   isBackendUnavailable?: boolean;
+  appVersion?: string;
+  backendVersion?: string | null;
 };
 
 export function getRecentSessions(sessions: Session[]) {
@@ -35,9 +37,12 @@ export function Dashboard({
   cameraStreamingControl,
   storageSync,
   isBackendUnavailable = false,
+  appVersion = __APP_VERSION__,
+  backendVersion = null,
 }: Props) {
   const abortedSessions = sessions.filter((s) => s.status === 'aborted');
   const recentSessions = getRecentSessions(sessions);
+  const versionsMatch = !backendVersion || backendVersion === appVersion;
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-8">
@@ -191,7 +196,15 @@ export function Dashboard({
         </div>
       </section>
 
-      <p className="text-center text-xs text-slate-300 pb-2">v{__APP_VERSION__}</p>
+      <section className="rounded-3xl border border-slate-100 bg-white p-4 text-center shadow-sm">
+        <p className="text-xs text-slate-400">Frontend v{appVersion} · Backend {backendVersion ? `v${backendVersion}` : 'unknown'}</p>
+        {!versionsMatch && (
+          <p className="mt-2 inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
+            <AlertTriangle size={14} />
+            Version mismatch — refresh or redeploy recommended.
+          </p>
+        )}
+      </section>
     </div>
   );
 }

--- a/apps/brave-paws-app/src/components/SettingsView.tsx
+++ b/apps/brave-paws-app/src/components/SettingsView.tsx
@@ -9,6 +9,7 @@ type Props = {
   isBackendAvailable: boolean;
   onBack: () => void;
   onBackendRootUrlChange: (backendRootUrl: string | null) => void;
+  onBackendVersionChange?: (backendVersion: string | null) => void;
   onSettingsChange: (settings: AppSettings) => void;
 };
 
@@ -18,6 +19,7 @@ export function SettingsView({
   isBackendAvailable,
   onBack,
   onBackendRootUrlChange,
+  onBackendVersionChange,
   onSettingsChange,
 }: Props) {
   const incrementMode = settings.longestDepartureIncrement.mode;
@@ -129,6 +131,7 @@ export function SettingsView({
           currentBackendRootUrl={currentBackendRootUrl}
           isBackendAvailable={isBackendAvailable}
           onBackendRootUrlChange={onBackendRootUrlChange}
+          onBackendVersionChange={onBackendVersionChange}
         />
       </section>
     </div>

--- a/apps/brave-paws-app/tests/dashboard-info-button.test.js
+++ b/apps/brave-paws-app/tests/dashboard-info-button.test.js
@@ -18,4 +18,6 @@ test('Dashboard keeps training available locally and describes connected feature
   assert.match(dashboard, /remote camera control/);
   assert.match(dashboard, /session recording/);
   assert.match(dashboard, /without a separate companion app/);
+  assert.match(dashboard, /Frontend v\{/);
+  assert.match(dashboard, /Version mismatch — refresh or redeploy recommended\./);
 });

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs/promises';
-import { createReadStream } from 'node:fs';
+import { createReadStream, readFileSync } from 'node:fs';
 import http, { type IncomingMessage, type ServerResponse } from 'node:http';
 import path from 'node:path';
 
@@ -29,6 +29,10 @@ import {
   writeSessionStore,
 } from './storage.js';
 import type { Session } from './types.js';
+
+const { version: appVersion = 'dev' } = JSON.parse(
+  readFileSync(new URL('../../../package.json', import.meta.url), 'utf8'),
+) as { version?: string };
 
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',
@@ -735,6 +739,9 @@ async function handleApiRequest(
     const store = await readSessionStore(config.dataFilePath);
     sendJson(response, 200, {
       status: 'ok',
+      service: 'brave-paws-server',
+      version: appVersion,
+      writeAuthRequired: Boolean(config.authToken),
       publicBaseUrl: config.publicBaseUrl,
       appBasePath: config.appBasePath,
       apiBasePath: config.apiBasePath,

--- a/apps/brave-paws-server/src/server.ts
+++ b/apps/brave-paws-server/src/server.ts
@@ -30,9 +30,18 @@ import {
 } from './storage.js';
 import type { Session } from './types.js';
 
-const { version: appVersion = 'dev' } = JSON.parse(
-  readFileSync(new URL('../../../package.json', import.meta.url), 'utf8'),
-) as { version?: string };
+export function loadAppVersion(packageJsonUrl = new URL('../../../package.json', import.meta.url)): string {
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonUrl, 'utf8')) as {
+      version?: unknown;
+    };
+    return typeof parsed.version === 'string' && parsed.version.trim() ? parsed.version : 'dev';
+  } catch {
+    return 'dev';
+  }
+}
+
+const appVersion = loadAppVersion();
 
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -117,16 +117,39 @@ async function withFixtureServer(
   }
 }
 
-test('health endpoint reports session metadata without leaking server file paths', async () => {
+test('health endpoint reports version/auth/session metadata without leaking server file paths', async () => {
   await withFixtureServer(async ({ baseUrl }) => {
     const response = await fetch(`${baseUrl}/separation/api/health`);
     assert.equal(response.status, 200);
-    const body = await response.json() as { status: string; sessionCount: number; dataFilePath?: string; csvFilePath?: string; clientDiagnosticsFilePath?: string };
+    const body = await response.json() as {
+      status: string;
+      service: string;
+      version: string;
+      writeAuthRequired: boolean;
+      sessionCount: number;
+      dataFilePath?: string;
+      csvFilePath?: string;
+      clientDiagnosticsFilePath?: string;
+    };
     assert.equal(body.status, 'ok');
+    assert.equal(body.service, 'brave-paws-server');
+    assert.match(body.version, /^\d+\.\d+\.\d+$/);
+    assert.equal(body.writeAuthRequired, false);
     assert.equal(body.sessionCount, 0);
     assert.equal(body.dataFilePath, undefined);
     assert.equal(body.csvFilePath, undefined);
     assert.equal(body.clientDiagnosticsFilePath, undefined);
+  });
+});
+
+test('health endpoint reports when write auth is required', async () => {
+  await withFixtureServer(async ({ baseUrl }) => {
+    const response = await fetch(`${baseUrl}/separation/api/health`);
+    assert.equal(response.status, 200);
+    const body = await response.json() as { writeAuthRequired: boolean };
+    assert.equal(body.writeAuthRequired, true);
+  }, {
+    authToken: 'test-token',
   });
 });
 

--- a/apps/brave-paws-server/tests/server.test.ts
+++ b/apps/brave-paws-server/tests/server.test.ts
@@ -5,7 +5,7 @@ import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 
-import { createBravePawsServer } from '../src/server.ts';
+import { createBravePawsServer, loadAppVersion } from '../src/server.ts';
 import { type BravePawsServerConfig } from '../src/config.ts';
 import { getSessionsCsvFilePath } from '../src/storage.ts';
 
@@ -116,6 +116,14 @@ async function withFixtureServer(
     await fs.rm(tempDir, { recursive: true, force: true });
   }
 }
+
+test('loadAppVersion falls back to dev when package.json is unreadable or invalid', () => {
+  const missingUrl = new URL('file:///definitely-missing-package.json');
+  assert.equal(loadAppVersion(missingUrl), 'dev');
+
+  const invalidPackageJsonUrl = new URL(`data:application/json,${encodeURIComponent('{not json}')}`);
+  assert.equal(loadAppVersion(invalidPackageJsonUrl), 'dev');
+});
 
 test('health endpoint reports version/auth/session metadata without leaking server file paths', async () => {
   await withFixtureServer(async ({ baseUrl }) => {

--- a/deploy/scripts/install-brave-paws-cd-sync-timer.sh
+++ b/deploy/scripts/install-brave-paws-cd-sync-timer.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+UNIT_SOURCE="$REPO_ROOT/deploy/systemd/brave-paws-cd-sync.service"
+TIMER_SOURCE="$REPO_ROOT/deploy/systemd/brave-paws-cd-sync.timer"
+UNIT_DEST="/etc/systemd/system/brave-paws-cd-sync.service"
+TIMER_DEST="/etc/systemd/system/brave-paws-cd-sync.timer"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run this installer as root (for example via sudo)." >&2
+  exit 1
+fi
+
+install -m 0644 "$UNIT_SOURCE" "$UNIT_DEST"
+install -m 0644 "$TIMER_SOURCE" "$TIMER_DEST"
+systemctl daemon-reload
+systemctl enable --now brave-paws-cd-sync.timer
+systemctl start brave-paws-cd-sync.service
+systemctl status brave-paws-cd-sync.timer --no-pager
+
+echo
+echo "Installed: $TIMER_DEST"
+echo "Service: $UNIT_DEST"
+echo "Live repo: $HOME/services/separation-tracker-live"

--- a/deploy/scripts/sync-brave-paws-backend-to-latest-release.sh
+++ b/deploy/scripts/sync-brave-paws-backend-to-latest-release.sh
@@ -7,8 +7,8 @@ SERVICE_NAME="${BRAVE_PAWS_SYSTEMD_SERVICE_NAME:-brave-paws.service}"
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/brave-paws"
 STATE_FILE="$STATE_DIR/cd-sync-state.json"
 HEALTHCHECK_URL="${BRAVE_PAWS_HEALTHCHECK_URL:-http://127.0.0.1:4310/separation/api/health}"
-USER_UNIT_SOURCE_REL="deploy/systemd/brave-paws.service"
-USER_UNIT_DEST="/etc/systemd/system/${SERVICE_NAME}"
+SYSTEMD_UNIT_SOURCE_REL="${BRAVE_PAWS_SYSTEMD_UNIT_SOURCE_REL:-deploy/systemd/brave-paws.live.service}"
+SYSTEMD_UNIT_DEST="${BRAVE_PAWS_SYSTEMD_UNIT_DEST:-/etc/systemd/system/${SERVICE_NAME}}"
 DRY_RUN=0
 FORCE=0
 
@@ -120,8 +120,8 @@ current_branch=$current_branch
 current_sha=$current_sha
 service_state=$service_state
 last_release_id=$last_release_id
-user_unit_source=$REPO_ROOT/$USER_UNIT_SOURCE_REL
-user_unit_dest=$USER_UNIT_DEST
+systemd_unit_source=$REPO_ROOT/$SYSTEMD_UNIT_SOURCE_REL
+systemd_unit_dest=$SYSTEMD_UNIT_DEST
 need_sync=$need_sync
 EOF
   exit 0
@@ -137,7 +137,7 @@ if [[ "$current_branch" != "main" ]]; then
 fi
 
 git reset --hard "$desired_sha"
-install -D -m 0644 "$REPO_ROOT/$USER_UNIT_SOURCE_REL" "$USER_UNIT_DEST"
+install -D -m 0644 "$REPO_ROOT/$SYSTEMD_UNIT_SOURCE_REL" "$SYSTEMD_UNIT_DEST"
 systemctl daemon-reload
 npm ci
 npm run build

--- a/deploy/scripts/sync-brave-paws-backend-to-latest-release.sh
+++ b/deploy/scripts/sync-brave-paws-backend-to-latest-release.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${BRAVE_PAWS_REPO_ROOT:-$HOME/services/separation-tracker-live}"
+REPO_SLUG="${BRAVE_PAWS_GITHUB_REPO:-harvey-cash/separation-tracker}"
+SERVICE_NAME="${BRAVE_PAWS_SYSTEMD_SERVICE_NAME:-brave-paws.service}"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/brave-paws"
+STATE_FILE="$STATE_DIR/cd-sync-state.json"
+HEALTHCHECK_URL="${BRAVE_PAWS_HEALTHCHECK_URL:-http://127.0.0.1:4310/separation/api/health}"
+USER_UNIT_SOURCE_REL="deploy/systemd/brave-paws.service"
+USER_UNIT_DEST="/etc/systemd/system/${SERVICE_NAME}"
+DRY_RUN=0
+FORCE=0
+
+usage() {
+  cat <<'EOF'
+Usage: sync-brave-paws-backend-to-latest-release.sh [--dry-run] [--force]
+
+Updates the live QUARK backend checkout to the latest release tag produced by
+separation-tracker CD on `main`, then rebuilds and restarts the backend service.
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    --force)
+      FORCE=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+mkdir -p "$STATE_DIR"
+cd "$REPO_ROOT"
+
+if [[ ! -d .git ]]; then
+  echo "Repo root is not a git checkout: $REPO_ROOT" >&2
+  exit 1
+fi
+
+tracked_dirty="$(git status --porcelain --untracked-files=no)"
+if [[ -n "$tracked_dirty" ]]; then
+  echo "Refusing to sync with tracked local changes present in $REPO_ROOT" >&2
+  git status --short --branch >&2
+  exit 1
+fi
+
+git fetch origin --prune --tags
+
+mapfile -t release_fields < <(git tag -l 'v*' | python3 -c 'import re, sys
+
+def version_key(tag: str):
+    m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag.strip())
+    if not m:
+        return (-1, -1, -1)
+    return tuple(int(part) for part in m.groups())
+
+tags = [line.strip() for line in sys.stdin if line.strip()]
+valid = [tag for tag in tags if version_key(tag) != (-1, -1, -1)]
+if not valid:
+    raise SystemExit(1)
+latest = max(valid, key=version_key)
+print(latest)
+')
+release_tag="${release_fields[0]:-}"
+
+if [[ -z "$release_tag" ]]; then
+  echo "Could not determine latest release tag for $REPO_SLUG" >&2
+  exit 1
+fi
+
+release_id="$release_tag"
+release_published_at="$(git log -1 --format=%cI "refs/tags/$release_tag")"
+
+if ! desired_sha="$(git rev-parse -q --verify "refs/tags/$release_tag^{commit}")"; then
+  echo "Latest release tag $release_tag is not available locally after fetch." >&2
+  exit 1
+fi
+
+current_branch="$(git branch --show-current || true)"
+current_sha="$(git rev-parse HEAD)"
+service_state="$(systemctl is-active "$SERVICE_NAME" 2>/dev/null || true)"
+last_release_id=""
+if [[ -f "$STATE_FILE" ]]; then
+  last_release_id="$(python3 - "$STATE_FILE" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1], 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+    print(data.get('release_id', ''))
+except Exception:
+    print('')
+PY
+)"
+fi
+
+need_sync=0
+if [[ "$FORCE" -eq 1 || "$current_branch" != "main" || "$current_sha" != "$desired_sha" || "$service_state" != "active" || "$last_release_id" != "$release_id" ]]; then
+  need_sync=1
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  cat <<EOF
+release_id=$release_id
+release_tag=$release_tag
+release_published_at=$release_published_at
+desired_sha=$desired_sha
+current_branch=$current_branch
+current_sha=$current_sha
+service_state=$service_state
+last_release_id=$last_release_id
+user_unit_source=$REPO_ROOT/$USER_UNIT_SOURCE_REL
+user_unit_dest=$USER_UNIT_DEST
+need_sync=$need_sync
+EOF
+  exit 0
+fi
+
+if [[ "$need_sync" -eq 0 ]]; then
+  echo "Already synced to $release_tag ($desired_sha) with $SERVICE_NAME active."
+  exit 0
+fi
+
+if [[ "$current_branch" != "main" ]]; then
+  git switch main >/dev/null
+fi
+
+git reset --hard "$desired_sha"
+install -D -m 0644 "$REPO_ROOT/$USER_UNIT_SOURCE_REL" "$USER_UNIT_DEST"
+systemctl daemon-reload
+npm ci
+npm run build
+systemctl restart "$SERVICE_NAME"
+sleep 2
+health_json="$(curl -fsS "$HEALTHCHECK_URL")"
+health_version="$(printf '%s' "$health_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("version", ""))')"
+applied_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+python3 - "$STATE_FILE" <<PY
+import json
+from pathlib import Path
+path = Path(${STATE_FILE@Q})
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps({
+  "release_id": ${release_id@Q},
+  "release_tag": ${release_tag@Q},
+  "release_published_at": ${release_published_at@Q},
+  "desired_sha": ${desired_sha@Q},
+  "health_version": ${health_version@Q},
+  "applied_at": ${applied_at@Q}
+}, indent=2) + "\n", encoding="utf-8")
+PY
+
+echo "Synced $SERVICE_NAME to $release_tag ($desired_sha); health version=$health_version"

--- a/deploy/scripts/sync-brave-paws-backend-to-latest-release.sh
+++ b/deploy/scripts/sync-brave-paws-backend-to-latest-release.sh
@@ -58,22 +58,24 @@ fi
 
 git fetch origin --prune --tags
 
-mapfile -t release_fields < <(git tag -l 'v*' | python3 -c 'import re, sys
+mapfile -t release_fields < <(gh release list --exclude-drafts --exclude-pre-releases --limit 100 --json tagName,publishedAt,isLatest | python3 -c 'import json, re, sys
 
-def version_key(tag: str):
-    m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag.strip())
-    if not m:
-        return (-1, -1, -1)
-    return tuple(int(part) for part in m.groups())
-
-tags = [line.strip() for line in sys.stdin if line.strip()]
-valid = [tag for tag in tags if version_key(tag) != (-1, -1, -1)]
+releases = json.load(sys.stdin)
+valid = []
+for release in releases:
+    tag = (release.get("tagName") or "").strip()
+    match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
+    if not match:
+        continue
+    valid.append((tuple(int(part) for part in match.groups()), tag, release.get("publishedAt") or ""))
 if not valid:
     raise SystemExit(1)
-latest = max(valid, key=version_key)
-print(latest)
+_, latest_tag, published_at = max(valid, key=lambda item: item[0])
+print(latest_tag)
+print(published_at)
 ')
 release_tag="${release_fields[0]:-}"
+release_published_at="${release_fields[1]:-}"
 
 if [[ -z "$release_tag" ]]; then
   echo "Could not determine latest release tag for $REPO_SLUG" >&2
@@ -81,7 +83,10 @@ if [[ -z "$release_tag" ]]; then
 fi
 
 release_id="$release_tag"
-release_published_at="$(git log -1 --format=%cI "refs/tags/$release_tag")"
+if [[ -z "$release_published_at" ]]; then
+  echo "Could not determine published_at for $release_tag" >&2
+  exit 1
+fi
 
 if ! desired_sha="$(git rev-parse -q --verify "refs/tags/$release_tag^{commit}")"; then
   echo "Latest release tag $release_tag is not available locally after fetch." >&2

--- a/deploy/systemd/brave-paws-cd-sync.service
+++ b/deploy/systemd/brave-paws-cd-sync.service
@@ -5,5 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-WorkingDirectory=%h/services/separation-tracker-live
-ExecStart=%h/services/separation-tracker-live/deploy/scripts/sync-brave-paws-backend-to-latest-release.sh
+Environment=BRAVE_PAWS_REPO_ROOT=/home/harvey/services/separation-tracker-live
+Environment=XDG_STATE_HOME=/home/harvey/.local/state
+WorkingDirectory=/home/harvey/services/separation-tracker-live
+ExecStart=/home/harvey/services/separation-tracker-live/deploy/scripts/sync-brave-paws-backend-to-latest-release.sh

--- a/deploy/systemd/brave-paws-cd-sync.service
+++ b/deploy/systemd/brave-paws-cd-sync.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Sync Brave Paws backend to latest released main on QUARK
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/services/separation-tracker-live
+ExecStart=%h/services/separation-tracker-live/deploy/scripts/sync-brave-paws-backend-to-latest-release.sh

--- a/deploy/systemd/brave-paws-cd-sync.timer
+++ b/deploy/systemd/brave-paws-cd-sync.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Poll latest Brave Paws release and sync QUARK backend after CD
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+Unit=brave-paws-cd-sync.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/brave-paws.live.service
+++ b/deploy/systemd/brave-paws.live.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Brave Paws local Tailnet server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=harvey
+Group=harvey
+WorkingDirectory=/home/harvey/services/separation-tracker-live
+Environment=BRAVE_PAWS_HOST=127.0.0.1
+Environment=BRAVE_PAWS_PORT=4310
+Environment=BRAVE_PAWS_PUBLIC_BASE_URL=https://quark.tail080401.ts.net:7447
+Environment="BRAVE_PAWS_CORS_ALLOWED_ORIGINS=https://harvey.cash,https://www.harvey.cash"
+Environment="BRAVE_PAWS_DATA_DIR=/mnt/q/fermi/brave-paws/data"
+Environment="BRAVE_PAWS_RECORDINGS_DIR=/mnt/s/Fermi/Separation Training Sessions/Brave Paws"
+Environment=BRAVE_PAWS_CAMERA_UPSTREAM_BASE_URL=http://127.0.0.1:18888/
+Environment=BRAVE_PAWS_CAMERA_CONTROL_PROVIDER=command
+Environment="BRAVE_PAWS_CAMERA_CONTROL_LABEL=Picam streaming"
+Environment="BRAVE_PAWS_CAMERA_STATUS_COMMAND=/home/harvey/services/separation-tracker-live/deploy/scripts/brave-paws-picam-camera-control.sh status"
+Environment="BRAVE_PAWS_CAMERA_ENABLE_COMMAND=/home/harvey/services/separation-tracker-live/deploy/scripts/brave-paws-picam-camera-control.sh enable"
+Environment="BRAVE_PAWS_CAMERA_DISABLE_COMMAND=/home/harvey/services/separation-tracker-live/deploy/scripts/brave-paws-picam-camera-control.sh disable"
+Environment=BRAVE_PAWS_RECORDING_PROVIDER=command
+Environment="BRAVE_PAWS_RECORDING_LABEL=Session recording"
+Environment="BRAVE_PAWS_RECORDING_STATUS_COMMAND=/home/harvey/services/separation-tracker-live/deploy/scripts/brave-paws-picam-recording-control.sh status"
+Environment="BRAVE_PAWS_RECORDING_START_COMMAND=/home/harvey/services/separation-tracker-live/deploy/scripts/brave-paws-picam-recording-control.sh start"
+Environment="BRAVE_PAWS_RECORDING_STOP_COMMAND=/home/harvey/services/separation-tracker-live/deploy/scripts/brave-paws-picam-recording-control.sh stop"
+Environment="BRAVE_PAWS_RECORDING_VIDEO_HEIGHT=540"
+Environment="BRAVE_PAWS_RECORDING_VIDEO_BITRATE=800k"
+Environment="BRAVE_PAWS_RECORDING_VIDEO_MAXRATE=1000k"
+Environment="BRAVE_PAWS_RECORDING_VIDEO_BUFSIZE=1600k"
+Environment="BRAVE_PAWS_RECORDING_AUDIO_BITRATE=96k"
+ExecStart=/usr/bin/env npm --prefix /home/harvey/services/separation-tracker-live run server:start
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -96,7 +96,7 @@ The live release-follow job:
 - fetches repo tags and selects the highest `vX.Y.Z` release created by CD
 - resets the live clone to that tagged commit on `main`
 - runs `npm ci` and `npm run build`
-- reinstalls the canonical `deploy/systemd/brave-paws.service`
+- reinstalls the canonical `deploy/systemd/brave-paws.live.service`
 - restarts `brave-paws.service`
 - records the applied release in `~/.local/state/brave-paws/cd-sync-state.json`
 

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -89,6 +89,8 @@ For the durable live backend path that mirrors `harvey-dashboard`, keep a separa
 sudo ~/services/separation-tracker-live/deploy/scripts/install-brave-paws-cd-sync-timer.sh
 ```
 
+The live release-follow job uses `deploy/systemd/brave-paws.live.service` as the canonical unit source for the dedicated live clone.
+
 The live release-follow job:
 
 - fetches repo tags and selects the highest `vX.Y.Z` release created by CD

--- a/docs/quantum-local-tailnet.md
+++ b/docs/quantum-local-tailnet.md
@@ -81,6 +81,25 @@ Session recordings live separately under `${BRAVE_PAWS_RECORDINGS_DIR}` so the m
    ```
 5. Expose the server through Tailscale Serve so `/separation/...` stays Tailnet-only
 
+## Automated QUARK live release-follow sync
+
+For the durable live backend path that mirrors `harvey-dashboard`, keep a separate live clone on QUARK (recommended: `~/services/separation-tracker-live`) and install the release-follow timer there:
+
+```bash
+sudo ~/services/separation-tracker-live/deploy/scripts/install-brave-paws-cd-sync-timer.sh
+```
+
+The live release-follow job:
+
+- fetches repo tags and selects the highest `vX.Y.Z` release created by CD
+- resets the live clone to that tagged commit on `main`
+- runs `npm ci` and `npm run build`
+- reinstalls the canonical `deploy/systemd/brave-paws.service`
+- restarts `brave-paws.service`
+- records the applied release in `~/.local/state/brave-paws/cd-sync-state.json`
+
+That path is intentionally separate from the staging worktree automation below, so release-follow deploys do not fight with local dev/staging refreshes.
+
 ## Automated QUARK staging refresh
 
 QUARK staging is meant to follow the local development repo's latest committed HEAD automatically, without hand-editing `/etc/systemd/system/brave-paws.service`.


### PR DESCRIPTION
## Summary
- surface Brave Paws backend version/auth info from the health endpoint
- show frontend/backend version mismatch in the app UI
- add a QUARK live-clone release-follow sync script plus systemd timer/service/docs, mirroring harvey-dashboard

## Testing
- npm test
- npm run lint

## Review
@harvey-cash